### PR TITLE
feat: filter TOC, page headers, and footers from document chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - **Trim mitigation sources to 3 frameworks**: dropped MIT AI Risk Repository (831 actions, 60% of index) and Credo UCF (41 controls) from the mitigation index. Kept NIST AI RMF 600-1, OWASP LLM Top 10 v2.0, and AIUC-1. Index reduced from 1,693 to 552 action-risk links across 80 risks (was 83). Max mitigations per risk drops from 162 to 26. MIT was dominated by governance questionnaires with ~24% sourced from NIST anyway; Credo overlapped heavily with NIST policy guidance.
+- **Filter TOC, page headers, and page footers from chunks**: the chunker's serializer now excludes `DOCUMENT_INDEX`, `PAGE_HEADER`, and `PAGE_FOOTER` labels, preventing table-of-contents entries and repetitive boilerplate from entering the retrieval pipeline
 
 ### Added
 - **In-context causal chain synthesis**: new post-merge pipeline stage that uses the LLM to synthesize domain-specific causal chains (`threat`, `threat_source`, `vulnerability`, `consequence`, `impact`) grounded in the actual policy document. Replaces static YAML-sourced chains with actionable, context-aware decompositions. Enabled by default when an LLM is available; disable with `--no-causal-synthesis`. Static YAML chains serve as fallback for risks where synthesis fails or is disabled.

--- a/src/concorde_policy_mapper/extract/parse.py
+++ b/src/concorde_policy_mapper/extract/parse.py
@@ -101,7 +101,23 @@ def _get_serializer_provider():
         SerializationResult,
     )
     from docling_core.transforms.serializer.common import create_ser_result
-    from docling_core.types.doc.document import DoclingDocument, TableData, TableItem
+    from docling_core.transforms.serializer.markdown import (
+        ImageRefMode,
+        MarkdownParams,
+    )
+    from docling_core.types.doc.document import (
+        DOCUMENT_TOKENS_EXPORT_LABELS,
+        DoclingDocument,
+        TableData,
+        TableItem,
+    )
+    from docling_core.types.doc.labels import DocItemLabel
+
+    _CHUNKING_LABELS = DOCUMENT_TOKENS_EXPORT_LABELS - {
+        DocItemLabel.DOCUMENT_INDEX,
+        DocItemLabel.PAGE_HEADER,
+        DocItemLabel.PAGE_FOOTER,
+    }
 
     class KVTableSerializer(BaseTableSerializer):
         def serialize(
@@ -128,6 +144,13 @@ def _get_serializer_provider():
 
     class KVChunkingDocSerializer(ChunkingDocSerializer):
         table_serializer: BaseTableSerializer = KVTableSerializer()
+        params: MarkdownParams = MarkdownParams(
+            labels=_CHUNKING_LABELS,
+            image_mode=ImageRefMode.PLACEHOLDER,
+            image_placeholder="",
+            escape_underscores=False,
+            escape_html=False,
+        )
 
     class KVSerializerProvider(BaseSerializerProvider):
         def get_serializer(self, doc: DoclingDocument) -> BaseDocSerializer:


### PR DESCRIPTION
Exclude DOCUMENT_INDEX, PAGE_HEADER, and PAGE_FOOTER labels from the chunker's serializer allowlist. TOC entries are duplicated headings that add retrieval noise; headers/footers were already excluded by the BODY content layer but are now explicitly removed for defense-in-depth.
