### PR TITLE
feat: add Credo UCF to mitigation crossmap

### DIFF
--- a/src/concorde_policy_mapper/extract/mitigations.py
+++ b/src/concorde_policy_mapper/extract/mitigations.py
@@ -78,6 +78,7 @@ def build_risk_crossmap(nexus_base_dir: str) -> dict[str, set[str]]:
 
     mapping_files = [
         "mit-ai-risk-repository_ibm-risk-atlas_from_tsv_data.yaml",
+        "credo-ucf.sssom_from_tsv_data.yaml",
     ]
     predicates = ("close_mappings", "related_mappings", "broad_mappings", "exact_mappings")
 

--- a/tests/test_mitigations.py
+++ b/tests/test_mitigations.py
@@ -343,16 +343,20 @@ def test_build_risk_crossmap_credo(tmp_path):
     mappings_dir.mkdir()
 
     (mappings_dir / "credo-ucf.sssom_from_tsv_data.yaml").write_text(
-        yaml.dump({"entries": [
+        yaml.dump(
             {
-                "id": "credo-risk-005",
-                "close_mappings": ["atlas-data-transparency"],
-            },
-            {
-                "id": "atlas-harmful-output",
-                "related_mappings": ["credo-risk-003"],
-            },
-        ]})
+                "entries": [
+                    {
+                        "id": "credo-risk-005",
+                        "close_mappings": ["atlas-data-transparency"],
+                    },
+                    {
+                        "id": "atlas-harmful-output",
+                        "related_mappings": ["credo-risk-003"],
+                    },
+                ]
+            }
+        )
     )
 
     crossmap = build_risk_crossmap(str(tmp_path))

--- a/tests/test_mitigations.py
+++ b/tests/test_mitigations.py
@@ -337,6 +337,30 @@ def test_build_risk_crossmap_bidirectional(tmp_path):
     assert crossmap["mit-risk-099"] == {"atlas-model-theft"}
 
 
+def test_build_risk_crossmap_credo(tmp_path):
+    """Credo SSSOM file produces credo → atlas entries."""
+    mappings_dir = _make_nexus_kg(tmp_path) / "mappings"
+    mappings_dir.mkdir()
+
+    (mappings_dir / "credo-ucf.sssom_from_tsv_data.yaml").write_text(
+        yaml.dump({"entries": [
+            {
+                "id": "credo-risk-005",
+                "close_mappings": ["atlas-data-transparency"],
+            },
+            {
+                "id": "atlas-harmful-output",
+                "related_mappings": ["credo-risk-003"],
+            },
+        ]})
+    )
+
+    crossmap = build_risk_crossmap(str(tmp_path))
+
+    assert crossmap["credo-risk-005"] == {"atlas-data-transparency"}
+    assert crossmap["credo-risk-003"] == {"atlas-harmful-output"}
+
+
 def test_build_risk_crossmap_missing_files(tmp_path):
     """Non-existent mappings dir returns empty dict."""
     crossmap = build_risk_crossmap(str(tmp_path / "nonexistent"))


### PR DESCRIPTION
## Summary
- Add `credo-ucf.sssom_from_tsv_data.yaml` to `build_risk_crossmap()` mapping files list
- Enables 32 Credo UCF risks to resolve to Atlas risk IDs for mitigation lookup
- Previously only MIT mappings were loaded, leaving all 49 Credo risks without a path to Atlas mitigations

## Test plan
- [x] New `test_build_risk_crossmap_credo` test verifies Credo→Atlas entries are extracted
- [x] All 23 existing mitigation tests pass
- [x] Verified live: `build_risk_crossmap()` returns 32 Credo keys with correct Atlas targets