### PR TITLE
feat: add YAML output format for risk extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **YAML output format**: `--output-format yaml` (or `both`) writes `risk-extraction.yaml` alongside or instead of JSON. The `eval` command auto-detects whichever format is present and writes eval results back into all existing output files. Default remains JSON for backward compatibility.
 - **mypy type checking**: added mypy with Pydantic plugin to dev dependencies and CI pipeline. Configured in `pyproject.toml` with `check_untyped_defs`, `warn_return_any`, and per-module import overrides for untyped deps (rank_bm25, nltk, ai_atlas_nexus). Fixed all existing type errors across `llm.py`, `index.py`, `pipeline.py`, `debug.py`, `parse.py`, and `retrieve.py`. Added `just type-check` target and wired mypy into the `tidy` CI job.
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ uv run concorde-policy-mapper extract policy.pdf -o output/ \
   --base-url http://localhost:8000/v1 --model my-model \
   --nexus-base-dir /path/to/ai-atlas-nexus
 
+# Output as YAML instead of JSON (or both)
+uv run concorde-policy-mapper extract policy.pdf -o output/ \
+  --base-url http://localhost:8000/v1 --model my-model \
+  --nexus-base-dir /path/to/ai-atlas-nexus --output-format yaml
+# --output-format: json (default), yaml, or both
+
 # Evaluate against ground truth
 uv run concorde-policy-mapper eval output/ -g evals/ground_truth/policy-name.yaml
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ uv run concorde-policy-mapper extract policy.pdf -o output/ \
   --nexus-base-dir /path/to/ai-atlas-nexus
 ```
 
-Outputs `risk-extraction.json` and `risk-extraction.html` report.
+Outputs `risk-extraction.json` and `risk-extraction.html` report. Use `--output-format yaml` to get `risk-extraction.yaml` instead, or `--output-format both` for both.
 
 ### Evaluate against ground truth
 

--- a/src/concorde_policy_mapper/cli.py
+++ b/src/concorde_policy_mapper/cli.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import typer
+import yaml
 
 from concorde_policy_mapper import debug
 from concorde_policy_mapper.llm import LLMConfig, TokenTracker, create_client
@@ -113,6 +114,9 @@ def extract(
     query_gen: bool = typer.Option(
         True, "--query-gen/--no-query-gen", help="LLM query generation for retrieval (default: on)"
     ),
+    output_format: str = typer.Option(
+        "json", "--output-format", "-f", help="Output format: json, yaml, or both (default: json)"
+    ),
     temperature: float = typer.Option(0.0, "--temperature", help="LLM sampling temperature (default: 0.0)"),
     top_p: float = typer.Option(None, "--top-p", help="LLM nucleus sampling top-p (omitted if not set)"),
     top_k: int = typer.Option(
@@ -120,6 +124,11 @@ def extract(
     ),
 ):
     """Extract risks from policy documents using hybrid retrieval."""
+    valid_formats = {"json", "yaml", "both"}
+    if output_format not in valid_formats:
+        typer.echo(f"Error: --output-format must be one of: {', '.join(sorted(valid_formats))}", err=True)
+        raise typer.Exit(1)
+
     for pf in policy_files:
         if not pf.exists():
             typer.echo(f"Error: {pf} does not exist", err=True)
@@ -232,9 +241,18 @@ def extract(
         typer.echo(f"  Mitigations attached from {len(mitigation_index)} risk entries")
 
     result_data = result.model_dump()
-    result_path = output / "risk-extraction.json"
-    result_path.write_text(json.dumps(result_data, indent=2))
-    typer.echo(f"Risk extraction written to {result_path}")
+
+    write_json = output_format in ("json", "both")
+    write_yaml = output_format in ("yaml", "both")
+
+    if write_json:
+        json_path = output / "risk-extraction.json"
+        json_path.write_text(json.dumps(result_data, indent=2))
+        typer.echo(f"Risk extraction written to {json_path}")
+    if write_yaml:
+        yaml_path = output / "risk-extraction.yaml"
+        yaml_path.write_text(yaml.dump(result_data, default_flow_style=False, sort_keys=False, allow_unicode=True))
+        typer.echo(f"Risk extraction written to {yaml_path}")
     typer.echo(f"  {len(result.risks)} risks matched")
     stats = result.retrieval_stats
     if no_judge and no_grounding:
@@ -272,9 +290,14 @@ def eval_cmd(
     min_precision: float = typer.Option(0.60, "--min-precision", help="Minimum precision threshold"),
 ):
     """Evaluate a risk extraction run against ground truth."""
-    extracted_path = run_dir / "risk-extraction.json"
-    if not extracted_path.exists():
-        typer.echo(f"Error: {extracted_path} not found", err=True)
+    json_path = run_dir / "risk-extraction.json"
+    yaml_path = run_dir / "risk-extraction.yaml"
+    if json_path.exists():
+        extracted_path = json_path
+    elif yaml_path.exists():
+        extracted_path = yaml_path
+    else:
+        typer.echo(f"Error: no risk-extraction.json or .yaml found in {run_dir}", err=True)
         raise typer.Exit(1)
 
     if ground_truth is None:
@@ -298,9 +321,17 @@ def eval_cmd(
     eval_path = run_dir / "eval.json"
     eval_path.write_text(json.dumps(result, indent=2))
 
-    extraction_data = json.loads(extracted_path.read_text())
+    raw = extracted_path.read_text()
+    if extracted_path.suffix == ".yaml":
+        extraction_data = yaml.safe_load(raw)
+    else:
+        extraction_data = json.loads(raw)
     extraction_data["eval"] = result
-    extracted_path.write_text(json.dumps(extraction_data, indent=2))
+
+    if json_path.exists():
+        json_path.write_text(json.dumps(extraction_data, indent=2))
+    if yaml_path.exists():
+        yaml_path.write_text(yaml.dump(extraction_data, default_flow_style=False, sort_keys=False, allow_unicode=True))
 
     from concorde_policy_mapper.extract.report import build_risk_extraction_report
 


### PR DESCRIPTION
## Summary
- Adds `--output-format` / `-f` flag to `extract` command: `json` (default), `yaml`, or `both`
- `eval` command auto-detects `risk-extraction.json` or `.yaml` and writes eval results back into all present formats
- Fulfills the RHAISTRAT-1924 acceptance criterion: "Output is a structured, versioned risk extraction result (YAML/JSON)"

## Test plan
- [x] All 296 fast tests pass
- [x] Lint, format, type-check clean
- [ ] Run `extract --output-format yaml` and verify `risk-extraction.yaml` is written
- [ ] Run `extract --output-format both` and verify both files are written
- [ ] Run `eval` against a YAML-only output dir and verify it loads correctly