### PR TITLE
security: replace nltk with spacy sentencizer (CVE-2026-54293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **mypy type checking**: added mypy with Pydantic plugin to dev dependencies and CI pipeline. Configured in `pyproject.toml` with `check_untyped_defs`, `warn_return_any`, and per-module import overrides for untyped deps (rank_bm25, nltk, ai_atlas_nexus). Fixed all existing type errors across `llm.py`, `index.py`, `pipeline.py`, `debug.py`, `parse.py`, and `retrieve.py`. Added `just type-check` target and wired mypy into the `tidy` CI job.
 
 ### Security
+- **Remove `nltk` dependency** (CVE-2026-54293, high): replaced `nltk.sent_tokenize()` with spacy's rule-based `sentencizer` for sentence splitting. Eliminates the path traversal vulnerability in `nltk.data.load()` and removes the `punkt_tab` model download at import time.
 - **Remove `pylate` dependency** (GHSA-g4r7-86gm-pgqc, high): pylate was declared as a direct dependency but never imported — ColBERT support uses `sentence-transformers` directly. Removing it eliminates the transitive `sqlitedict` unsafe-deserialization vulnerability.
 - **Pin `aiohttp>=3.14.0`** (GHSA-hg6j-4rv6-33pg, GHSA-jg22-mg44-37j8, medium): fixes cross-origin redirect cookie leak and untrusted-data deserialization in aiohttp (transitive via instructor/mlflow).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "ai-atlas-nexus @ git+https://github.com/IBM/ai-atlas-nexus.git@main",
     "sentence-transformers>=3.0",
     "rank-bm25>=0.2",
-    "nltk>=3.8",
+    "spacy>=3.7",
     "numpy",
     "mlflow>=2.17",
     "aiohttp>=3.14.0",
@@ -61,7 +61,7 @@ check_untyped_defs = true
 plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
-module = ["rank_bm25.*", "nltk.*", "ai_atlas_nexus.*"]
+module = ["rank_bm25.*", "ai_atlas_nexus.*"]
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/src/concorde_policy_mapper/extract/retrieve.py
+++ b/src/concorde_policy_mapper/extract/retrieve.py
@@ -4,7 +4,7 @@ import logging
 import time
 from dataclasses import dataclass
 
-import nltk
+import spacy
 
 from concorde_policy_mapper.extract.models import LLMCallRecord, ScoredCandidate, _JudgeVerdict
 from concorde_policy_mapper.extract.parse import Chunk
@@ -12,14 +12,14 @@ from concorde_policy_mapper.prompts import render_prompt
 
 logger = logging.getLogger(__name__)
 
-nltk.download("punkt_tab", quiet=True)
+_nlp = spacy.blank("en")
+_nlp.add_pipe("sentencizer")
 
 
 def _sent_tokenize(text: str) -> list[str]:
-    try:
-        return nltk.sent_tokenize(text)  # type: ignore[no-any-return]  # nltk lacks py.typed
-    except Exception:
-        return [text] if text.strip() else []
+    if not text.strip():
+        return []
+    return [sent.text for sent in _nlp(text).sents]
 
 
 def build_chunk_contexts(


### PR DESCRIPTION
## Summary
- Removes `nltk` dependency (CVE-2026-54293 — path traversal in `nltk.data.load()`)
- Replaces `nltk.sent_tokenize()` with spacy's rule-based `sentencizer` for sentence splitting in judge context padding
- Eliminates `punkt_tab` model download at import time
- Adds `spacy>=3.7` as explicit dependency (was not a transitive dep)

## Test plan
- [x] All 296 fast tests pass
- [x] All 28 slow tests pass (sentence splitting equivalence verified)
- [x] Lint, format, type-check clean