### PR TITLE
docs: reduce CLAUDE.md toward minimal AGENTS.md guideline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,6 @@ Runs `concorde-policy-mapper extract` as a subprocess per policy in a battery YA
 
 ## Development
 
-- `AGENTS.md` is a symlink to `CLAUDE.md` — they are the same file, not two copies. Do not treat them as separate files or suggest deduplication.
+- `AGENTS.md` is a symlink to `CLAUDE.md` — they are the same file. Do not treat them as separate files or suggest deduplication.
 - DO NOT skip updating the changelog with any changes made
-- DO NOT skip updating AGENTS.md and the README.md when changes require it
+- DO NOT skip updating `CLAUDE.md`/`AGENTS.md` and `README.md` when changes require it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,66 +41,7 @@ just type-check
 # Type check single file
 uv run mypy path/to/file.py
 
-# Extract risks from a document
-uv run concorde-policy-mapper extract policy.pdf -o output/ \
-  --base-url http://localhost:8000/v1 --model my-model \
-  --nexus-base-dir /path/to/ai-atlas-nexus
-
-# Output as YAML instead of JSON (or both)
-uv run concorde-policy-mapper extract policy.pdf -o output/ \
-  --base-url http://localhost:8000/v1 --model my-model \
-  --nexus-base-dir /path/to/ai-atlas-nexus --output-format yaml
-# --output-format: json (default), yaml, or both
-
-# Evaluate against ground truth
-uv run concorde-policy-mapper eval output/ -g evals/ground_truth/policy-name.yaml
-
-# Run full battery (27 policies, parallel)
-just run-risk-extract-battery batteries/risk-selected.yaml <base-url> <model>
-# Or directly with more options:
-python run_extract_battery.py batteries/risk-selected.yaml --base-url <url> --model <model> -j 6
-# Default config: expand-siblings + 3-pass grounding + 3-pass expansion
-
-# Run battery with MLflow tracking disabled
-just no_mlflow="1" run-risk-extract-battery batteries/risk-selected.yaml <base-url> <model>
-
-# Run battery with custom MLflow experiment name
-python run_extract_battery.py batteries/risk-selected.yaml --base-url <url> --model <model> --mlflow-experiment my-experiment
-
-# IR-only mode (no LLM judge/grounding, no --base-url/--model needed)
-uv run concorde-policy-mapper extract policy.pdf -o output/ \
-  --nexus-base-dir /path/to/ai-atlas-nexus --no-judge --no-grounding
-just no_judge="1" no_grounding="1" run-risk-extract-battery batteries/risk-selected.yaml
-
-# Judge only, no grounding (test judge contribution in isolation)
-uv run concorde-policy-mapper extract policy.pdf -o output/ \
-  --nexus-base-dir /path/to/ai-atlas-nexus --no-grounding \
-  --base-url <url> --model <model>
-
-# Skip causal synthesis (use static YAML chains)
-uv run concorde-policy-mapper extract policy.pdf -o output/ \
-  --nexus-base-dir /path/to/ai-atlas-nexus --no-causal-synthesis \
-  --base-url <url> --model <model>
-
-# Smaller chunks with larger judge context window
-uv run concorde-policy-mapper extract policy.pdf -o output/ \
-  --nexus-base-dir /path/to/ai-atlas-nexus \
-  --chunk-max-tokens 256 --judge-context-tokens 512 \
-  --base-url <url> --model <model>
-
-# Use remote embedding models on GPU cluster
-uv run concorde-policy-mapper extract policy.pdf -o output/ --no-judge --no-grounding \
-  --nexus-base-dir /path/to/ai-atlas-nexus \
-  --bi-encoder-model https://bge-m3-model-serving.apps.example.com/v1/embeddings \
-  --cross-encoder-model https://gte-reranker-model-serving.apps.example.com/v1/score
-
-# Disable LLM query generation (use raw chunk text for retrieval)
-uv run concorde-policy-mapper extract policy.pdf -o output/ \
-  --nexus-base-dir /path/to/ai-atlas-nexus --no-query-gen \
-  --base-url <url> --model <model>
-
-# Rebuild mitigation index (after data file changes)
-python scripts/build_mitigation_index.py
+# See README.md for full CLI usage examples (extract, eval, battery, remote models)
 ```
 
 ## Architecture
@@ -206,5 +147,6 @@ Runs `concorde-policy-mapper extract` as a subprocess per policy in a battery YA
 
 ## Development
 
+- `AGENTS.md` is a symlink to `CLAUDE.md` — they are the same file, not two copies. Do not treat them as separate files or suggest deduplication.
 - DO NOT skip updating the changelog with any changes made
 - DO NOT skip updating AGENTS.md and the README.md when changes require it

--- a/README.md
+++ b/README.md
@@ -176,6 +176,48 @@ just run-risk-extract-battery batteries/risk-selected.yaml <base-url> <model>
 
 Runs extraction + eval across all policies in the battery config, generates per-run reports and a summary with per-taxonomy heatmaps.
 
+### Advanced Usage
+
+```bash
+# Battery with more options (direct invocation)
+python run_extract_battery.py batteries/risk-selected.yaml --base-url <url> --model <model> -j 6
+
+# Battery with MLflow tracking disabled
+just no_mlflow="1" run-risk-extract-battery batteries/risk-selected.yaml <base-url> <model>
+
+# Battery with custom MLflow experiment name
+python run_extract_battery.py batteries/risk-selected.yaml --base-url <url> --model <model> --mlflow-experiment my-experiment
+
+# IR-only mode (no LLM judge/grounding, no --base-url/--model needed)
+uv run concorde-policy-mapper extract policy.pdf -o output/ \
+  --nexus-base-dir /path/to/ai-atlas-nexus --no-judge --no-grounding
+just no_judge="1" no_grounding="1" run-risk-extract-battery batteries/risk-selected.yaml
+
+# Judge only, no grounding (test judge contribution in isolation)
+uv run concorde-policy-mapper extract policy.pdf -o output/ \
+  --nexus-base-dir /path/to/ai-atlas-nexus --no-grounding \
+  --base-url <url> --model <model>
+
+# Skip causal synthesis (use static YAML chains)
+uv run concorde-policy-mapper extract policy.pdf -o output/ \
+  --nexus-base-dir /path/to/ai-atlas-nexus --no-causal-synthesis \
+  --base-url <url> --model <model>
+
+# Smaller chunks with larger judge context window
+uv run concorde-policy-mapper extract policy.pdf -o output/ \
+  --nexus-base-dir /path/to/ai-atlas-nexus \
+  --chunk-max-tokens 256 --judge-context-tokens 512 \
+  --base-url <url> --model <model>
+
+# Disable LLM query generation (use raw chunk text for retrieval)
+uv run concorde-policy-mapper extract policy.pdf -o output/ \
+  --nexus-base-dir /path/to/ai-atlas-nexus --no-query-gen \
+  --base-url <url> --model <model>
+
+# Rebuild mitigation index (after data file changes)
+python scripts/build_mitigation_index.py
+```
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## Summary

- Move CLI usage examples (extract, eval, battery, remote models) from CLAUDE.md to README.md "Advanced Usage" section
- Reduce CLAUDE.md/AGENTS.md from 210 to 152 lines toward the "minimal AGENTS.md (under 150 lines, hand-written)" guideline from the "WG Agentic SDLC repo scaffolding best practices"
- Document that AGENTS.md is a symlink to CLAUDE.md (prevents agents from suggesting deduplication)
- No content removed — only moved to its natural home

## Rationale

The agent context file (CLAUDE.md / AGENTS.md) should contain only what agents can't discover on their own. CLI usage examples are user-facing documentation that agents can discover via `--help`. Keeping the context file lean improves agent adherence to the lines that matter (dev workflow commands, conventions, design invariants).

## Test plan

- [x] Every CLI example from CLAUDE.md verified present in README.md (17/17 checked)
- [x] AGENTS.md confirmed still a symlink to CLAUDE.md
- [x] Dev workflow commands (test/lint/format/type-check) unchanged in CLAUDE.md

Co-Authored-By: Claude <noreply@anthropic.com>

> Every CLI example from CLAUDE.md verified present in README.md (17/17 checked)

I have also manually checked this, some examples where already present (actually 1 of the "moved"/removed was already present in README.md but in CLAUDE.md was missing base-url) and the other examples have been moved correctly.