### PR TITLE
fix: wrap bare list[Model] response_model for instructor compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Instructor compatibility**: wrap bare `list[Model]` response models (`_JudgeVerdict`, `_RiskEvidence`, `_CausalChain`) in Pydantic wrapper classes (`_JudgeVerdicts`, `_RiskEvidenceList`, `_CausalChains`). Instructor 1.15.3+ calls `.model_json_schema()` on the response model, which fails on `list[...]`. Fixes 5 call sites across `retrieve.py` and `attribute.py`.
+
 ### Changed
 - **Project renamed** from `concorde-policy-mapper` to `asago-policy-mapper`. Python module is now `asago_policy_mapper`. CLI command is now `asago-policy-mapper`.
 

--- a/src/asago_policy_mapper/extract/attribute.py
+++ b/src/asago_policy_mapper/extract/attribute.py
@@ -9,7 +9,8 @@ from asago_policy_mapper.extract.models import (
     RiskMatch,
     ScoredCandidate,
     _CausalChain,
-    _RiskEvidence,
+    _CausalChains,
+    _RiskEvidenceList,
 )
 from asago_policy_mapper.prompts import render_prompt
 
@@ -56,11 +57,12 @@ def ground_and_extract_evidence(
         )
 
         t0 = time.time()
-        verdicts: list[_RiskEvidence] = client.chat.completions.create(
+        verdicts_resp = client.chat.completions.create(
             model=model,
-            response_model=list[_RiskEvidence],
+            response_model=_RiskEvidenceList,
             messages=messages,
         )
+        verdicts = verdicts_resp.items
         duration_ms = (time.time() - t0) * 1000
 
         batch_ids = {c.risk_id for c in batch}
@@ -132,11 +134,12 @@ def ground_variants(
     )
 
     t0 = time.time()
-    verdicts: list[_RiskEvidence] = client.chat.completions.create(
+    verdicts_resp = client.chat.completions.create(
         model=model,
-        response_model=list[_RiskEvidence],
+        response_model=_RiskEvidenceList,
         messages=messages,
     )
+    verdicts = verdicts_resp.items
     duration_ms = (time.time() - t0) * 1000
 
     variant_ids = {v["risk_id"] for v in variants}
@@ -208,11 +211,12 @@ def ground_risk_group(
     )
 
     t0 = time.time()
-    verdicts: list[_RiskEvidence] = client.chat.completions.create(
+    verdicts_resp = client.chat.completions.create(
         model=model,
-        response_model=list[_RiskEvidence],
+        response_model=_RiskEvidenceList,
         messages=messages,
     )
+    verdicts = verdicts_resp.items
     duration_ms = (time.time() - t0) * 1000
 
     risk_ids = {r["risk_id"] for r in risks}
@@ -288,11 +292,12 @@ def synthesize_causal_chain(
     )
 
     t0 = time.time()
-    results: list[_CausalChain] = client.chat.completions.create(
+    results_resp = client.chat.completions.create(
         model=model,
-        response_model=list[_CausalChain],
+        response_model=_CausalChains,
         messages=messages,
     )
+    results = results_resp.items
     duration_ms = (time.time() - t0) * 1000
 
     chain = results[0] if results else None

--- a/src/asago_policy_mapper/extract/models.py
+++ b/src/asago_policy_mapper/extract/models.py
@@ -139,6 +139,10 @@ class _JudgeVerdict(BaseModel):
     justification: str
 
 
+class _JudgeVerdicts(BaseModel):
+    items: list[_JudgeVerdict]
+
+
 class _GroundingVerdict(BaseModel):
     risk_id: str
     grounded: bool
@@ -152,12 +156,20 @@ class _RiskEvidence(BaseModel):
     quotes: list[str]
 
 
+class _RiskEvidenceList(BaseModel):
+    items: list[_RiskEvidence]
+
+
 class _CausalChain(BaseModel):
     threat: str
     threat_source: str
     vulnerability: str
     consequence: str
     impact: str
+
+
+class _CausalChains(BaseModel):
+    items: list[_CausalChain]
 
 
 @dataclass

--- a/src/asago_policy_mapper/extract/retrieve.py
+++ b/src/asago_policy_mapper/extract/retrieve.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import spacy
 
-from asago_policy_mapper.extract.models import LLMCallRecord, ScoredCandidate, _JudgeVerdict
+from asago_policy_mapper.extract.models import LLMCallRecord, ScoredCandidate, _JudgeVerdicts
 from asago_policy_mapper.extract.parse import Chunk
 from asago_policy_mapper.prompts import render_prompt
 
@@ -234,11 +234,12 @@ def judge_borderline(
         )
 
         t0 = time.time()
-        verdicts: list[_JudgeVerdict] = client.chat.completions.create(
+        verdicts_resp = client.chat.completions.create(
             model=model,
-            response_model=list[_JudgeVerdict],
+            response_model=_JudgeVerdicts,
             messages=messages,
         )
+        verdicts = verdicts_resp.items
         duration_ms = (time.time() - t0) * 1000
 
         batch_ids = {c.risk_id for c in batch}

--- a/tests/test_extract_attribute.py
+++ b/tests/test_extract_attribute.py
@@ -13,27 +13,31 @@ from asago_policy_mapper.extract.models import (
     RiskMatch,
     ScoredCandidate,
     _CausalChain,
+    _CausalChains,
     _RiskEvidence,
+    _RiskEvidenceList,
 )
 from asago_policy_mapper.prompts import render_prompt
 
 
 def test_ground_and_extract_evidence_returns_grounded():
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        MagicMock(
-            risk_id="R-001",
-            grounded=True,
-            confidence="high",
-            quotes=["AI bias was detected in the outputs.", "The model shows systematic bias."],
-        ),
-        MagicMock(
-            risk_id="R-002",
-            grounded=False,
-            confidence="low",
-            quotes=[],
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = MagicMock(
+        items=[
+            MagicMock(
+                risk_id="R-001",
+                grounded=True,
+                confidence="high",
+                quotes=["AI bias was detected in the outputs.", "The model shows systematic bias."],
+            ),
+            MagicMock(
+                risk_id="R-002",
+                grounded=False,
+                confidence="low",
+                quotes=[],
+            ),
+        ]
+    )
 
     candidates = [
         ScoredCandidate(
@@ -89,14 +93,16 @@ def test_ground_and_extract_evidence_empty_candidates():
 
 def test_ground_and_extract_evidence_ignores_unknown_risk_ids():
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        MagicMock(
-            risk_id="R-UNKNOWN",
-            grounded=True,
-            confidence="medium",
-            quotes=["Some quote."],
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = MagicMock(
+        items=[
+            MagicMock(
+                risk_id="R-UNKNOWN",
+                grounded=True,
+                confidence="medium",
+                quotes=["Some quote."],
+            ),
+        ]
+    )
 
     candidates = [
         ScoredCandidate(
@@ -120,14 +126,16 @@ def test_ground_and_extract_evidence_ignores_unknown_risk_ids():
 
 def test_ground_and_extract_evidence_skips_empty_quotes():
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        MagicMock(
-            risk_id="R-001",
-            grounded=True,
-            confidence="high",
-            quotes=["Valid quote.", "", "  "],
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = MagicMock(
+        items=[
+            MagicMock(
+                risk_id="R-001",
+                grounded=True,
+                confidence="high",
+                quotes=["Valid quote.", "", "  "],
+            ),
+        ]
+    )
 
     candidates = [
         ScoredCandidate(
@@ -161,14 +169,16 @@ def test_ground_and_extract_evidence_captures_call(mock_client):
             cross_encoder_score=0.9,
         ),
     ]
-    mock_client.chat.completions.create.return_value = [
-        _RiskEvidence(
-            risk_id="R-001",
-            grounded=True,
-            confidence="high",
-            quotes=["AI systems must avoid bias"],
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+        items=[
+            _RiskEvidence(
+                risk_id="R-001",
+                grounded=True,
+                confidence="high",
+                quotes=["AI systems must avoid bias"],
+            ),
+        ]
+    )
 
     collector: list[LLMCallRecord] = []
     result = ground_and_extract_evidence(
@@ -200,9 +210,9 @@ def test_ground_and_extract_evidence_no_collector(mock_client):
             cross_encoder_score=0.9,
         ),
     ]
-    mock_client.chat.completions.create.return_value = [
-        _RiskEvidence(risk_id="R-001", grounded=True, confidence="high", quotes=["text"]),
-    ]
+    mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+        items=[_RiskEvidence(risk_id="R-001", grounded=True, confidence="high", quotes=["text"])]
+    )
 
     result = ground_and_extract_evidence(
         chunk_text="text",
@@ -227,20 +237,22 @@ def _make_chunks(texts: list[str]):
 
 def test_ground_risk_group_returns_grounded():
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        _RiskEvidence(
-            risk_id="R-001",
-            grounded=True,
-            confidence="high",
-            quotes=["AI bias was detected."],
-        ),
-        _RiskEvidence(
-            risk_id="R-002",
-            grounded=False,
-            confidence="low",
-            quotes=[],
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+        items=[
+            _RiskEvidence(
+                risk_id="R-001",
+                grounded=True,
+                confidence="high",
+                quotes=["AI bias was detected."],
+            ),
+            _RiskEvidence(
+                risk_id="R-002",
+                grounded=False,
+                confidence="low",
+                quotes=[],
+            ),
+        ]
+    )
 
     chunks = _make_chunks(["Chunk zero text.", "AI bias was detected. Data is clean."])
     risks = [
@@ -324,14 +336,16 @@ def test_ground_risk_group_out_of_range_chunks():
 
 def test_ground_risk_group_ignores_unknown_risk_ids():
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        _RiskEvidence(
-            risk_id="R-UNKNOWN",
-            grounded=True,
-            confidence="medium",
-            quotes=["Some evidence."],
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+        items=[
+            _RiskEvidence(
+                risk_id="R-UNKNOWN",
+                grounded=True,
+                confidence="medium",
+                quotes=["Some evidence."],
+            ),
+        ]
+    )
 
     chunks = _make_chunks(["Some text with evidence."])
     risks = [
@@ -352,14 +366,16 @@ def test_ground_risk_group_ignores_unknown_risk_ids():
 
 def test_ground_risk_group_skips_empty_quotes():
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        _RiskEvidence(
-            risk_id="R-001",
-            grounded=True,
-            confidence="high",
-            quotes=["", "  ", ""],
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+        items=[
+            _RiskEvidence(
+                risk_id="R-001",
+                grounded=True,
+                confidence="high",
+                quotes=["", "  ", ""],
+            ),
+        ]
+    )
 
     chunks = _make_chunks(["Chunk text here."])
     risks = [
@@ -384,20 +400,22 @@ def test_ground_risk_group_captures_call(mock_client):
         {"risk_id": "R-001", "risk_name": "Bias", "risk_description": "Model bias risk."},
         {"risk_id": "R-002", "risk_name": "Privacy", "risk_description": "Data privacy risk."},
     ]
-    mock_client.chat.completions.create.return_value = [
-        _RiskEvidence(
-            risk_id="R-001",
-            grounded=True,
-            confidence="high",
-            quotes=["Chunk one with bias evidence."],
-        ),
-        _RiskEvidence(
-            risk_id="R-002",
-            grounded=False,
-            confidence="low",
-            quotes=[],
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+        items=[
+            _RiskEvidence(
+                risk_id="R-001",
+                grounded=True,
+                confidence="high",
+                quotes=["Chunk one with bias evidence."],
+            ),
+            _RiskEvidence(
+                risk_id="R-002",
+                grounded=False,
+                confidence="low",
+                quotes=[],
+            ),
+        ]
+    )
 
     collector: list[LLMCallRecord] = []
     result = ground_risk_group(
@@ -478,15 +496,17 @@ def _make_risk_match(risk_id="atlas-bias", chunk_indices=None):
 
 
 def test_synthesize_causal_chain_success(mock_client):
-    mock_client.chat.completions.create.return_value = [
-        _CausalChain(
-            threat="AI credit scoring discriminates against protected groups",
-            threat_source="Biased training data from historical lending decisions",
-            vulnerability="No fairness auditing of model outputs",
-            consequence="Qualified applicants denied credit",
-            impact="Financial exclusion",
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = _CausalChains(
+        items=[
+            _CausalChain(
+                threat="AI credit scoring discriminates against protected groups",
+                threat_source="Biased training data from historical lending decisions",
+                vulnerability="No fairness auditing of model outputs",
+                consequence="Qualified applicants denied credit",
+                impact="Financial exclusion",
+            ),
+        ]
+    )
 
     risk = _make_risk_match(chunk_indices=[0, 2])
     chunk_texts = {0: "AI in credit scoring must be fair.", 2: "Discrimination is prohibited."}
@@ -504,15 +524,17 @@ def test_synthesize_causal_chain_success(mock_client):
 
 
 def test_synthesize_causal_chain_empty_strings_return_none(mock_client):
-    mock_client.chat.completions.create.return_value = [
-        _CausalChain(
-            threat="",
-            threat_source="",
-            vulnerability="",
-            consequence="",
-            impact="",
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = _CausalChains(
+        items=[
+            _CausalChain(
+                threat="",
+                threat_source="",
+                vulnerability="",
+                consequence="",
+                impact="",
+            ),
+        ]
+    )
 
     risk = _make_risk_match()
     chunk_texts = {0: "Some text.", 2: "More text."}
@@ -528,15 +550,17 @@ def test_synthesize_causal_chain_empty_strings_return_none(mock_client):
 
 
 def test_synthesize_causal_chain_records_call(mock_client):
-    mock_client.chat.completions.create.return_value = [
-        _CausalChain(
-            threat="Threat",
-            threat_source="Source",
-            vulnerability="Vuln",
-            consequence="Consequence",
-            impact="Impact",
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = _CausalChains(
+        items=[
+            _CausalChain(
+                threat="Threat",
+                threat_source="Source",
+                vulnerability="Vuln",
+                consequence="Consequence",
+                impact="Impact",
+            ),
+        ]
+    )
 
     risk = _make_risk_match()
     chunk_texts = {0: "Text.", 2: "More."}

--- a/tests/test_extract_pipeline.py
+++ b/tests/test_extract_pipeline.py
@@ -12,7 +12,9 @@ from asago_policy_mapper.extract.models import (
     RiskMatch,
     ScoredCandidate,
     _CausalChain,
+    _CausalChains,
     _RiskEvidence,
+    _RiskEvidenceList,
 )
 from asago_policy_mapper.extract.pipeline import (
     _run_causal_synthesis,
@@ -52,7 +54,7 @@ def test_run_extraction_returns_extraction_result(mock_config, tmp_path):
     doc.write_text("AI systems must avoid bias and protect personal data. Training data integrity is critical.")
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = SimpleNamespace(items=[])
 
     result = run_extraction(
         documents=[doc],
@@ -116,7 +118,7 @@ def test_run_extraction_multiple_documents(mock_config, tmp_path):
         docs.append(doc)
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = SimpleNamespace(items=[])
 
     result = run_extraction(
         documents=docs,
@@ -137,7 +139,7 @@ def test_run_extraction_metadata(mock_config, tmp_path):
     doc.write_text("AI risk document.")
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = SimpleNamespace(items=[])
 
     result = run_extraction(
         documents=[doc],
@@ -159,7 +161,7 @@ def test_run_extraction_populates_chunks(mock_config, tmp_path):
     doc.write_text("AI systems must avoid bias and protect personal data. Training data integrity is critical.")
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = SimpleNamespace(items=[])
 
     result = run_extraction(
         documents=[doc],
@@ -190,7 +192,7 @@ def test_run_extraction_populates_llm_calls(mock_config, tmp_path):
     )
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = SimpleNamespace(items=[])
 
     result = run_extraction(
         documents=[doc],
@@ -247,7 +249,7 @@ def test_run_extraction_no_grounding_with_judge(mock_config, tmp_path):
     )
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = SimpleNamespace(items=[])
 
     result = run_extraction(
         documents=[doc],
@@ -311,7 +313,7 @@ def test_run_extraction_no_cross_encoder(mock_config, tmp_path):
     )
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = SimpleNamespace(items=[])
 
     result = run_extraction(
         documents=[doc],
@@ -398,7 +400,7 @@ def test_run_extraction_no_judge_with_grounding_accepted_by(mock_config, tmp_pat
     )
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = SimpleNamespace(items=[])
 
     result = run_extraction(
         documents=[doc],
@@ -500,53 +502,26 @@ def test_run_extraction_expand_siblings(mock_config, tmp_path):
         "Training data integrity is critical for model reliability."
     )
 
-    call_count = 0
-
-    def mock_create(**kwargs):
-        nonlocal call_count
-        call_count += 1
-        response_model = kwargs.get("response_model")
-        if response_model and hasattr(response_model, "__args__"):
-            inner = response_model.__args__[0]
-            if inner == _RiskEvidence:
-                return [
-                    _RiskEvidence(
-                        risk_id=rid,
-                        grounded=True,
-                        confidence="medium",
-                        quotes=["bias detection and mitigation"],
-                    )
-                    for rid in kwargs.get("_risk_ids", [])
-                ]
-        return []
-
     mock_client = MagicMock()
     mock_client.chat.completions.create.side_effect = lambda **kwargs: (
-        [
-            _RiskEvidence(
-                risk_id=r["risk_id"],
-                grounded=True,
-                confidence="medium",
-                quotes=["bias detection and mitigation"],
-            )
-            for r in (
-                kwargs.get("messages", [{}])[-1].get("risks", [])
-                if isinstance(kwargs.get("messages", [{}])[-1], dict)
-                else []
-            )
-        ]
+        _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=r["risk_id"],
+                    grounded=True,
+                    confidence="medium",
+                    quotes=["bias detection and mitigation"],
+                )
+                for r in (
+                    kwargs.get("messages", [{}])[-1].get("risks", [])
+                    if isinstance(kwargs.get("messages", [{}])[-1], dict)
+                    else []
+                )
+            ]
+        )
         if kwargs.get("response_model")
-        else []
+        else SimpleNamespace(items=[])
     )
-
-    mock_client.chat.completions.create.return_value = [
-        _RiskEvidence(
-            risk_id="R-001",
-            grounded=True,
-            confidence="high",
-            quotes=["bias detection"],
-        ),
-    ]
 
     result = run_extraction(
         documents=[doc],
@@ -603,7 +578,7 @@ def test_run_extraction_judge_with_cross_encoder(mock_config, tmp_path):
     )
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = SimpleNamespace(items=[])
 
     result = run_extraction(
         documents=[doc],
@@ -647,15 +622,17 @@ def test_run_causal_synthesis_populates_fields():
     ]
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        _CausalChain(
-            threat="Credit scoring discriminates",
-            threat_source="Biased training data",
-            vulnerability="No fairness audit",
-            consequence="Applicants denied credit",
-            impact="Financial exclusion",
-        ),
-    ]
+    mock_client.chat.completions.create.return_value = _CausalChains(
+        items=[
+            _CausalChain(
+                threat="Credit scoring discriminates",
+                threat_source="Biased training data",
+                vulnerability="No fairness audit",
+                consequence="Applicants denied credit",
+                impact="Financial exclusion",
+            ),
+        ]
+    )
 
     from asago_policy_mapper.llm import LLMConfig
 
@@ -692,9 +669,9 @@ def test_run_causal_synthesis_skips_empty_results():
     chunks = [SimpleNamespace(text="Unrelated text about data retention.")]
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        _CausalChain(threat="", threat_source="", vulnerability="", consequence="", impact=""),
-    ]
+    mock_client.chat.completions.create.return_value = _CausalChains(
+        items=[_CausalChain(threat="", threat_source="", vulnerability="", consequence="", impact="")]
+    )
 
     from asago_policy_mapper.llm import LLMConfig
 

--- a/tests/test_extract_retrieve.py
+++ b/tests/test_extract_retrieve.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from asago_policy_mapper.extract.models import LLMCallRecord, ScoredCandidate, _JudgeVerdict
+from asago_policy_mapper.extract.models import LLMCallRecord, ScoredCandidate, _JudgeVerdict, _JudgeVerdicts
 from asago_policy_mapper.extract.parse import Chunk
 from asago_policy_mapper.extract.retrieve import (
     build_chunk_contexts,
@@ -167,9 +167,9 @@ def test_classify_candidates_bm25_rescue_rank_based():
 
 def test_judge_borderline_accepts_relevant():
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        MagicMock(risk_id="R-001", relevant=True, justification="Text discusses bias."),
-    ]
+    mock_client.chat.completions.create.return_value = MagicMock(
+        items=[MagicMock(risk_id="R-001", relevant=True, justification="Text discusses bias.")]
+    )
     candidates = [
         ScoredCandidate(
             risk_id="R-001",
@@ -190,9 +190,9 @@ def test_judge_borderline_accepts_relevant():
 
 def test_judge_borderline_rejects_irrelevant():
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        MagicMock(risk_id="R-005", relevant=False, justification="No mention of jobs."),
-    ]
+    mock_client.chat.completions.create.return_value = MagicMock(
+        items=[MagicMock(risk_id="R-005", relevant=False, justification="No mention of jobs.")]
+    )
     candidates = [
         ScoredCandidate(
             risk_id="R-005",
@@ -219,9 +219,9 @@ def test_judge_borderline_empty_candidates():
 
 def test_judge_borderline_captures_call():
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = [
-        _JudgeVerdict(risk_id="R-001", relevant=True, justification="Relevant"),
-    ]
+    mock_client.chat.completions.create.return_value = _JudgeVerdicts(
+        items=[_JudgeVerdict(risk_id="R-001", relevant=True, justification="Relevant")]
+    )
     candidates = [
         ScoredCandidate(
             risk_id="R-001",
@@ -261,7 +261,7 @@ def test_judge_borderline_captures_call():
 def test_judge_borderline_no_collector():
     """Existing behavior: no collector arg, no error."""
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = []
+    mock_client.chat.completions.create.return_value = _JudgeVerdicts(items=[])
     candidates = [
         ScoredCandidate(
             risk_id="R-001",

--- a/tests/test_extract_variant_grounding.py
+++ b/tests/test_extract_variant_grounding.py
@@ -10,6 +10,7 @@ from asago_policy_mapper.extract.models import (
     RetrievalScores,
     RiskMatch,
     _RiskEvidence,
+    _RiskEvidenceList,
 )
 from asago_policy_mapper.extract.pipeline import (
     _ground_variants_one,
@@ -131,46 +132,48 @@ class TestGroundVariants:
     def test_selective_grounding(self):
         """LLM grounds 2 of 6 variants; only those 2 are returned."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id=VARIANTS[0]["risk_id"],
-                grounded=True,
-                confidence="high",
-                quotes=["facial recognition data was collected without consent"],
-            ),
-            _RiskEvidence(
-                risk_id=VARIANTS[1]["risk_id"],
-                grounded=False,
-                confidence="low",
-                quotes=[],
-                rejection_reason="No health data mentioned.",
-            ),
-            _RiskEvidence(
-                risk_id=VARIANTS[2]["risk_id"],
-                grounded=False,
-                confidence="low",
-                quotes=[],
-                rejection_reason="No financial data mentioned.",
-            ),
-            _RiskEvidence(
-                risk_id=VARIANTS[3]["risk_id"],
-                grounded=True,
-                confidence="medium",
-                quotes=["GPS tracking without user awareness"],
-            ),
-            _RiskEvidence(
-                risk_id=VARIANTS[4]["risk_id"],
-                grounded=False,
-                confidence="low",
-                quotes=[],
-            ),
-            _RiskEvidence(
-                risk_id=VARIANTS[5]["risk_id"],
-                grounded=False,
-                confidence="low",
-                quotes=[],
-            ),
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=VARIANTS[0]["risk_id"],
+                    grounded=True,
+                    confidence="high",
+                    quotes=["facial recognition data was collected without consent"],
+                ),
+                _RiskEvidence(
+                    risk_id=VARIANTS[1]["risk_id"],
+                    grounded=False,
+                    confidence="low",
+                    quotes=[],
+                    rejection_reason="No health data mentioned.",
+                ),
+                _RiskEvidence(
+                    risk_id=VARIANTS[2]["risk_id"],
+                    grounded=False,
+                    confidence="low",
+                    quotes=[],
+                    rejection_reason="No financial data mentioned.",
+                ),
+                _RiskEvidence(
+                    risk_id=VARIANTS[3]["risk_id"],
+                    grounded=True,
+                    confidence="medium",
+                    quotes=["GPS tracking without user awareness"],
+                ),
+                _RiskEvidence(
+                    risk_id=VARIANTS[4]["risk_id"],
+                    grounded=False,
+                    confidence="low",
+                    quotes=[],
+                ),
+                _RiskEvidence(
+                    risk_id=VARIANTS[5]["risk_id"],
+                    grounded=False,
+                    confidence="low",
+                    quotes=[],
+                ),
+            ]
+        )
 
         result = ground_variants(
             chunk_text="facial recognition data was collected without consent. GPS tracking without user awareness.",
@@ -206,15 +209,17 @@ class TestGroundVariants:
     def test_none_grounded(self):
         """LLM grounds 0 variants; empty result."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id=v["risk_id"],
-                grounded=False,
-                confidence="low",
-                quotes=[],
-            )
-            for v in VARIANTS
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=v["risk_id"],
+                    grounded=False,
+                    confidence="low",
+                    quotes=[],
+                )
+                for v in VARIANTS
+            ]
+        )
 
         result = ground_variants(
             chunk_text="Generic personal data processing without specifics.",
@@ -252,14 +257,16 @@ class TestGroundVariants:
     def test_ignores_unknown_variant_ids(self):
         """Verdicts for IDs not in the variant list are ignored."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id="some-unknown-id",
-                grounded=True,
-                confidence="high",
-                quotes=["Some evidence."],
-            ),
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id="some-unknown-id",
+                    grounded=True,
+                    confidence="high",
+                    quotes=["Some evidence."],
+                ),
+            ]
+        )
 
         result = ground_variants(
             chunk_text="Some text.",
@@ -278,14 +285,16 @@ class TestGroundVariants:
     def test_skips_empty_quotes(self):
         """Grounded verdict with only empty quotes → not included."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id=VARIANTS[0]["risk_id"],
-                grounded=True,
-                confidence="high",
-                quotes=["", "  ", ""],
-            ),
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=VARIANTS[0]["risk_id"],
+                    grounded=True,
+                    confidence="high",
+                    quotes=["", "  ", ""],
+                ),
+            ]
+        )
 
         result = ground_variants(
             chunk_text="Some text.",
@@ -303,14 +312,16 @@ class TestGroundVariants:
 
     def test_captures_call_record(self, mock_client):
         """Call collector records a variant_grounding stage entry."""
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id=VARIANTS[0]["risk_id"],
-                grounded=True,
-                confidence="high",
-                quotes=["Biometric data collected."],
-            ),
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=VARIANTS[0]["risk_id"],
+                    grounded=True,
+                    confidence="high",
+                    quotes=["Biometric data collected."],
+                ),
+            ]
+        )
 
         collector: list[LLMCallRecord] = []
         ground_variants(
@@ -372,14 +383,16 @@ class TestGroundVariantsOne:
     def test_returns_grounded_variants(self):
         """_ground_variants_one calls ground_variants and returns results."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id=VARIANTS[0]["risk_id"],
-                grounded=True,
-                confidence="high",
-                quotes=["biometric data"],
-            ),
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=VARIANTS[0]["risk_id"],
+                    grounded=True,
+                    confidence="high",
+                    quotes=["biometric data"],
+                ),
+            ]
+        )
 
         parent = _make_parent_match(chunk_index=0)
         chunks = _make_chunks(["biometric data processing without consent."])
@@ -446,14 +459,16 @@ class TestRunVariantGrounding:
     def test_partitions_parent_and_non_parent(self):
         """Parent matches get variant grounding; non-parent pass through."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id=VARIANTS[0]["risk_id"],
-                grounded=True,
-                confidence="high",
-                quotes=["biometric data"],
-            ),
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=VARIANTS[0]["risk_id"],
+                    grounded=True,
+                    confidence="high",
+                    quotes=["biometric data"],
+                ),
+            ]
+        )
 
         parent = _make_parent_match(chunk_index=0)
         non_parent = _make_non_parent_match()
@@ -476,14 +491,16 @@ class TestRunVariantGrounding:
     def test_variant_inherits_parent_scores(self):
         """Variant matches inherit the parent's retrieval scores."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id=VARIANTS[1]["risk_id"],
-                grounded=True,
-                confidence="medium",
-                quotes=["health records"],
-            ),
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=VARIANTS[1]["risk_id"],
+                    grounded=True,
+                    confidence="medium",
+                    quotes=["health records"],
+                ),
+            ]
+        )
 
         parent = _make_parent_match(chunk_index=0)
         chunks = _make_chunks(["health records were accessed."])
@@ -528,15 +545,17 @@ class TestRunVariantGrounding:
     def test_zero_variants_grounded_drops_parent(self):
         """If LLM grounds zero variants, parent is dropped entirely."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id=v["risk_id"],
-                grounded=False,
-                confidence="low",
-                quotes=[],
-            )
-            for v in VARIANTS
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=v["risk_id"],
+                    grounded=False,
+                    confidence="low",
+                    quotes=[],
+                )
+                for v in VARIANTS
+            ]
+        )
 
         parent = _make_parent_match(chunk_index=0)
         chunks = _make_chunks(["Generic data processing discussion."])
@@ -555,14 +574,16 @@ class TestRunVariantGrounding:
     def test_uses_chunk_contexts_when_provided(self):
         """When chunk_contexts is provided, uses padded text instead of raw chunk."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = [
-            _RiskEvidence(
-                risk_id=VARIANTS[0]["risk_id"],
-                grounded=True,
-                confidence="high",
-                quotes=["biometric data from padded context"],
-            ),
-        ]
+        mock_client.chat.completions.create.return_value = _RiskEvidenceList(
+            items=[
+                _RiskEvidence(
+                    risk_id=VARIANTS[0]["risk_id"],
+                    grounded=True,
+                    confidence="high",
+                    quotes=["biometric data from padded context"],
+                ),
+            ]
+        )
 
         parent = _make_parent_match(chunk_index=0)
         chunks = _make_chunks(["short chunk"])


### PR DESCRIPTION
## Summary
- Instructor 1.15.3+ calls `.model_json_schema()` on `response_model`, which fails on bare `list[...]` types
- Added Pydantic wrapper models (`_JudgeVerdicts`, `_RiskEvidenceList`, `_CausalChains`) with an `items` field
- Updated 5 call sites across `retrieve.py` and `attribute.py` to use wrappers and unwrap via `.items`
- Updated all test mocks across 4 test files to return wrapper objects

## Test plan
- [x] All 87 fast unit tests pass (`pytest -m "not slow"` on affected files)
- [x] All 26 slow pipeline integration tests pass
- [x] Full fast test suite passes (296 tests)
- [x] `ruff check` and `mypy` clean on changed source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)