### PR TITLE
feat: add --bi-encoder-api-key and --bi-encoder-model-name CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,25 @@ ColBERT late-interaction models are supported via `--colbert-model` (replaces bi
 
 Pass a **model name** to run locally (downloaded on first use), or a **URL** to use a remote model served via vLLM.
 
+**Authentication:** Remote endpoints typically require an API key. Pass it via flag or env var:
+
+| Flag | Env var | Description |
+|------|---------|-------------|
+| `--api-key` | `POLICY_MAPPER_API_KEY` | LLM API key |
+| `--bi-encoder-api-key` | `POLICY_MAPPER_BI_ENCODER_API_KEY` | Bi-encoder API key |
+
+If the model name differs from what can be derived from the endpoint URL (e.g. the hostname prefix), use `--bi-encoder-model-name` to set it explicitly.
+
 **Best quality** (Qwen3 + GTE, both on GPU cluster):
 
 ```bash
 uv run asago-policy-mapper extract policy.pdf -o output/ \
   --nexus-base-dir /path/to/ai-atlas-nexus \
-  --base-url http://localhost:8000/v1 --model my-model \
-  --bi-encoder-model https://qwen3-embedding-serving.example.com/v1/embeddings \
+  --base-url https://llm-serving.example.com/v1 --model my-model \
+  --api-key $LLM_API_KEY \
+  --bi-encoder-model https://qwen3-embedding-serving.example.com/v1 \
+  --bi-encoder-model-name Qwen3-Embedding-4B \
+  --bi-encoder-api-key $EMBEDDING_API_KEY \
   --cross-encoder-model https://gte-reranker-serving.example.com/v1/score \
   --query-instruction "Instruct: Given a text passage from an AI governance policy document, retrieve AI risk descriptions that are relevant to the concepts, requirements, or concerns discussed in the passage\nQuery: " \
   --expand-siblings
@@ -165,8 +177,10 @@ uv run asago-policy-mapper extract policy.pdf -o output/ \
 ```bash
 uv run asago-policy-mapper extract policy.pdf -o output/ \
   --nexus-base-dir /path/to/ai-atlas-nexus \
-  --base-url http://localhost:8000/v1 --model my-model \
-  --bi-encoder-model https://embeddinggemma-serving.example.com/v1/embeddings \
+  --base-url https://llm-serving.example.com/v1 --model my-model \
+  --api-key $LLM_API_KEY \
+  --bi-encoder-model https://embeddinggemma-serving.example.com/v1 \
+  --bi-encoder-api-key $EMBEDDING_API_KEY \
   --cross-encoder-model https://gte-reranker-serving.example.com/v1/score
 ```
 

--- a/src/asago_policy_mapper/cli.py
+++ b/src/asago_policy_mapper/cli.py
@@ -52,6 +52,12 @@ def extract(
         None, "--threshold-low", help="Legacy: absolute discard threshold (overrides rank-based)"
     ),
     bi_encoder_model: str = typer.Option("all-mpnet-base-v2", "--bi-encoder-model", help="Bi-encoder model"),
+    bi_encoder_api_key: str = typer.Option(
+        "none", "--bi-encoder-api-key", envvar="POLICY_MAPPER_BI_ENCODER_API_KEY", help="Bi-encoder API key"
+    ),
+    bi_encoder_model_name: str = typer.Option(
+        None, "--bi-encoder-model-name", help="Bi-encoder model name (overrides name derived from endpoint URL)"
+    ),
     query_instruction: str = typer.Option(
         None,
         "--query-instruction",
@@ -183,6 +189,8 @@ def extract(
 
     retrieval = RetrievalConfig(
         bi_encoder_model=bi_encoder_model,
+        bi_encoder_api_key=bi_encoder_api_key,
+        bi_encoder_model_name=bi_encoder_model_name or None,
         query_instruction=query_instruction if query_instruction is not None else RetrievalConfig.query_instruction,
         cross_encoder_model=cross_encoder_model,
         cross_encoder_type=cross_encoder_type,

--- a/src/asago_policy_mapper/extract/index.py
+++ b/src/asago_policy_mapper/extract/index.py
@@ -62,11 +62,19 @@ class _RemoteBiEncoder:
     but documents (corpus) are encoded without it.
     """
 
-    def __init__(self, url: str, batch_size: int = 64, query_instruction: str = ""):
+    def __init__(
+        self,
+        url: str,
+        batch_size: int = 64,
+        query_instruction: str = "",
+        api_key: str = "none",
+        model_name: str | None = None,
+    ):
         from openai import OpenAI
 
-        base_url, self._model = _parse_remote_url(url)
-        self._client = OpenAI(base_url=base_url, api_key="none")
+        base_url, derived_model = _parse_remote_url(url)
+        self._model = model_name if model_name else derived_model
+        self._client = OpenAI(base_url=base_url, api_key=api_key)
         self._batch_size = batch_size
         self._query_instruction = query_instruction
 
@@ -281,9 +289,11 @@ def _load_colbert(model_name, descriptions):
     return colbert, doc_embeddings
 
 
-def _load_bi_encoder(model_name, descriptions, query_instruction=""):
+def _load_bi_encoder(model_name, descriptions, query_instruction="", api_key="none", remote_model_name=None):
     if _is_remote(model_name):
-        remote = _RemoteBiEncoder(model_name, query_instruction=query_instruction)
+        remote = _RemoteBiEncoder(
+            model_name, query_instruction=query_instruction, api_key=api_key, model_name=remote_model_name
+        )
         try:
             embeddings = remote.encode(descriptions, normalize=True)
         except Exception as e:
@@ -420,6 +430,8 @@ class RiskIndex:
         colbert_model: str | None = None,
         query_instruction: str = "",
         cross_encoder_type: str = "score",
+        bi_encoder_api_key: str = "none",
+        bi_encoder_model_name: str | None = None,
     ):
         self._risk_ids: list[str] = []
         self._risk_meta: dict[str, dict] = {}
@@ -469,6 +481,8 @@ class RiskIndex:
                 bi_encoder_model,
                 descriptions,
                 query_instruction,
+                api_key=bi_encoder_api_key,
+                remote_model_name=bi_encoder_model_name,
             )
 
             if cross_encoder_model:

--- a/src/asago_policy_mapper/extract/models.py
+++ b/src/asago_policy_mapper/extract/models.py
@@ -175,6 +175,8 @@ class _CausalChains(BaseModel):
 @dataclass
 class RetrievalConfig:
     bi_encoder_model: str = "all-mpnet-base-v2"
+    bi_encoder_api_key: str = "none"
+    bi_encoder_model_name: str | None = None
     query_instruction: str = (
         "Given a text passage from an AI governance policy document, retrieve AI risk"
         " descriptions that are relevant to the concepts, requirements, or concerns"

--- a/src/asago_policy_mapper/extract/pipeline.py
+++ b/src/asago_policy_mapper/extract/pipeline.py
@@ -629,6 +629,8 @@ def run_extraction(
             colbert_model=retrieval.colbert_model,
             query_instruction=retrieval.query_instruction,
             cross_encoder_type=retrieval.cross_encoder_type,
+            bi_encoder_api_key=retrieval.bi_encoder_api_key,
+            bi_encoder_model_name=retrieval.bi_encoder_model_name,
         )
 
     call_collector: list[LLMCallRecord] = []

--- a/tests/test_extract_index.py
+++ b/tests/test_extract_index.py
@@ -240,6 +240,31 @@ def test_score_normalizer_nli_2d():
 
 
 @patch("openai.OpenAI")
+def test_remote_bi_encoder_model_name_override(mock_openai_cls):
+    mock_client = MagicMock()
+    mock_openai_cls.return_value = mock_client
+    mock_client.embeddings.create.return_value = SimpleNamespace(data=[SimpleNamespace(index=0, embedding=[0.1, 0.2])])
+    encoder = _RemoteBiEncoder("https://my-endpoint-model-serving.apps.example.com/v1", model_name="actual-qwen3-model")
+    encoder.encode(["test"], normalize=False)
+    call_kwargs = mock_client.embeddings.create.call_args.kwargs
+    assert call_kwargs["model"] == "actual-qwen3-model"
+
+
+@patch("openai.OpenAI")
+def test_remote_bi_encoder_default_api_key(mock_openai_cls):
+    _RemoteBiEncoder("https://bge-m3-model-serving.apps.example.com/v1/embeddings")
+    mock_openai_cls.assert_called_once()
+    assert mock_openai_cls.call_args.kwargs["api_key"] == "none"
+
+
+@patch("openai.OpenAI")
+def test_remote_bi_encoder_custom_api_key(mock_openai_cls):
+    _RemoteBiEncoder("https://bge-m3-model-serving.apps.example.com/v1/embeddings", api_key="my-secret-token")
+    mock_openai_cls.assert_called_once()
+    assert mock_openai_cls.call_args.kwargs["api_key"] == "my-secret-token"
+
+
+@patch("openai.OpenAI")
 def test_remote_bi_encoder_encode(mock_openai_cls):
     mock_client = MagicMock()
     mock_openai_cls.return_value = mock_client


### PR DESCRIPTION
Remote embedding endpoints behind auth require an API key that previously had no way to be passed — the _RemoteBiEncoder client was hardcoded to api_key="none". Similarly, the model name was always derived from the endpoint hostname, which breaks when the actual model name differs.

Adds --bi-encoder-api-key (env: POLICY_MAPPER_BI_ENCODER_API_KEY) and --bi-encoder-model-name flags, wired through RetrievalConfig → RiskIndex → _RemoteBiEncoder. Updates README with auth guidance and corrects the configuration examples accordingly.