### PR TITLE
feat: document-centric annotation view for extraction results

### DIFF
--- a/docs/annotation-view-implementation-plan.md
+++ b/docs/annotation-view-implementation-plan.md
@@ -1,0 +1,234 @@
+# Annotation View Implementation Plan
+
+## What This Is
+
+A document-centric HTML report for the Asago policy mapper that renders the source policy document with extracted risks highlighted inline at their evidence locations. This is a new output alongside the existing `risk-extraction.html` (which is risk-centric — a table of risks with expandable detail rows). The annotation view inverts the axis: the document text is primary, risks are overlaid on it.
+
+## Why We Need It
+
+Today, reviewing extraction results or validating ground truth requires holding two artifacts in your head: the source policy document and a structured risk report. The existing HTML report doesn't render the source document text — you see risks in a table, but you can't see them in context. For a 50-page PDF with 40+ extracted risks, this means manually cross-referencing evidence quotes back to the source paragraphs.
+
+The annotation view solves three problems:
+1. **Readability** — see what the pipeline found in each section of the document at a glance
+2. **Validation** — verify that evidence spans are correct and that the causal chain reasoning makes sense in context
+3. **Ground truth review** — when a GT YAML is provided, see which risks are matched (TP), spurious (FP), and missed (FN) overlaid on the document, so GT curators can fix gaps without switching between files
+
+## What We Discussed and Decided
+
+### Why not store full text in the JSON?
+We considered persisting full chunk text in `risk-extraction.json` (adding a `text` field to `ChunkSummary`). Decided against it because:
+- It bloats the JSON output
+- The JSON is meant to be a machine-readable downstream input (for scenario generator)
+- The annotation view is a presentation layer, not a data format change
+- The source document is available at extraction time anyway
+
+### Why re-parse the source document?
+`ChunkSummary.text_preview` is truncated to 200 characters (`pipeline.py:741`). Full chunk text is in memory during extraction but not persisted. Two options:
+1. Re-parse at report generation time via `parse_document()` + `chunk_documents()` — requires the original file and docling
+2. Persist full chunk text in JSON — contradicts the "no format changes" requirement
+
+**Decision:** Re-parse. The annotated view is generated either during the extraction run (when chunks are in memory) or via a separate CLI command that takes the source document path as input.
+
+### Evidence positioning
+`EvidenceSpan` carries `text`, `document`, `page`, `section`, `chunk_index`, `sentence_index` — but **no byte/character offsets**. Positioning works by:
+1. Finding the chunk via `chunk_index`
+2. Substring matching `EvidenceSpan.text` against the full chunk text
+3. Fuzzy fallback for minor differences (whitespace normalization, unicode, LLM-generated quote variations)
+
+### Causal chain display
+Each `RiskMatch` has causal chain fields: `threat`, `threat_source`, `vulnerability`, `consequence`, `impact`. These are displayed as an expandable view under each highlighted risk, giving reviewers the reasoning chain in context.
+
+### Ground truth comparison
+Reuses `evaluate_extraction()` from `eval.py:145`. This function is standalone (no battery-runner coupling) and returns `matched_ids`, `missing`, `spurious`, precision, recall, F1 via risk-ID-level set intersection. Key distinction:
+- **Matched and spurious** risks have evidence spans → render as classified inline annotations
+- **Missed** risks exist only in ground truth with no evidence spans → appear in the summary panel/sidebar, NOT inline (they can't be positioned in the document)
+
+### Color coding
+- **No GT overlay:** color-code by taxonomy or confidence (unclassified annotations)
+- **With GT overlay:** matched = green, spurious = yellow, missed = red (in sidebar only). Use colorblind-safe palette with non-color cues (shape, label, or pattern) in both light and dark modes.
+
+## Current State of the Codebase
+
+### Files you need to understand
+
+| File | What it does | Why it matters |
+|------|-------------|----------------|
+| `src/asago_policy_mapper/extract/report.py` | `build_risk_extraction_report()` — reads HTML template, injects JSON data, writes self-contained HTML | **Pattern to follow.** New function `build_annotation_report()` goes here. |
+| `src/asago_policy_mapper/templates/risk_extraction_report_template.html` | 888-line Alpine.js + Tailwind template for the risk-centric report | **Tech stack reference.** New template uses the same stack. |
+| `src/asago_policy_mapper/templates/dark_mode_snippet.html` | Dark mode CSS/JS snippet injected into reports | Reuse for annotation view. |
+| `src/asago_policy_mapper/extract/models.py` | Pydantic models: `ExtractionResult`, `RiskMatch`, `EvidenceSpan`, `ChunkSummary` | **Data shapes.** `EvidenceSpan` has `text`, `chunk_index`, `page`, `section`. `RiskMatch` has causal chain fields. `ChunkSummary.text_preview` is truncated to 200 chars. |
+| `src/asago_policy_mapper/extract/parse.py` | `parse_document()` → `ParsedDocument`, `chunk_documents()` → `list[Chunk]`. `Chunk` has `text`, `source`, `index`, `page`, `section`. | Used to re-parse and get full chunk text. |
+| `src/asago_policy_mapper/extract/pipeline.py` | `run_extraction()` → `ExtractionResult`. Chunks built at line ~735. | Where to hook in annotation report generation during extraction. |
+| `src/asago_policy_mapper/cli.py` | typer CLI. `extract` command (line 29), `eval` command (line 286). Report generated at line 280-282 (extract) and 339-341 (eval). | New `annotate` CLI command goes here, mirroring `eval`. |
+| `src/asago_policy_mapper/evals/eval.py` | `evaluate_extraction()` at line 145. Takes `(ground_truth_path, extracted_path)`, returns dict with `matched_ids`, `missing`, `spurious`, metrics. | Reuse for GT comparison mode. |
+| `evals/ground_truth/*.yaml` | GT files. Format: `risks: [{id: "atlas-hallucination", evidence: [{text: "...", section: "..."}]}]` | Input for comparison mode. |
+
+### How the existing report works
+
+```
+cli.py (extract command, line 280):
+    result_data = result.model_dump()
+    build_risk_extraction_report(result_data, output / "risk-extraction.html")
+
+report.py:
+    def build_risk_extraction_report(data, output_path):
+        html = template.read_text().replace("__REPORT_DATA__", json.dumps(data))
+        html = inject_dark_mode(html)
+        output_path.write_text(html)
+```
+
+The template is a single self-contained HTML file. All data is embedded as a JSON blob. The template renders client-side with Alpine.js + Tailwind. No external dependencies, opens from filesystem in any browser.
+
+### Key data shapes
+
+```python
+# EvidenceSpan (models.py:43)
+class EvidenceSpan(BaseModel):
+    text: str                    # The evidence quote
+    document: str                # Source document name
+    page: int | None = None
+    section: str | None = None
+    chunk_index: int             # Which chunk this came from
+    sentence_index: int = 0
+    cross_encoder_score: float = 0.0
+
+# RiskMatch (models.py:60) — each extracted risk
+class RiskMatch(BaseModel):
+    risk_id: str
+    risk_name: str
+    risk_description: str
+    taxonomy: str = ""
+    confidence: float
+    grounding_confidence: str    # "high", "medium", "low"
+    accepted_by: str             # "auto", "judge", "grounding"
+    evidence: list[EvidenceSpan]
+    scores: RetrievalScores
+    mitigations: list[MitigationRef] = []
+    threat: str | None = None           # causal chain
+    threat_source: str | None = None    # causal chain
+    vulnerability: str | None = None    # causal chain
+    consequence: str | None = None      # causal chain
+    impact: str | None = None           # causal chain
+
+# Chunk (parse.py:30) — full text available here, NOT in ChunkSummary
+@dataclass(frozen=True)
+class Chunk:
+    text: str           # FULL chunk text
+    source: str
+    index: int
+    page: int | None = None
+    section: str | None = None
+
+# Ground truth YAML format
+risks:
+  - id: atlas-hallucination
+    evidence:
+      - text: "Outputs created by GenAI tools may provide fictitious answers..."
+        section: "IV. Additional specific rules..."
+```
+
+### evaluate_extraction return shape
+
+```python
+{
+    "policy": "amadeus",
+    "total_expected": 25,
+    "total_extracted": 158,
+    "matched": 22,
+    "matched_ids": ["atlas-hallucination", "atlas-decision-bias", ...],
+    "missing": ["atlas-some-risk", ...],        # in GT but not extracted
+    "spurious": ["atlas-other-risk", ...],      # extracted but not in GT
+    "precision": 0.139,
+    "recall": 0.880,
+    "f1": 0.240,
+    "pass": true,
+    "per_taxonomy": {...},
+    "category_eval": {...}
+}
+```
+
+## Implementation Tasks
+
+Each task is an independent, testable PR that builds on the previous one. No pipeline changes. No new dependencies — re-parsing uses existing `parse_document()` + `chunk_documents()`, fuzzy matching uses stdlib `difflib`, GT comparison calls existing `evaluate_extraction()`, report builder follows the existing template pattern, and the HTML template uses the same Alpine.js + Tailwind CDN stack.
+
+---
+
+### Task 1: Data preparation layer with evidence span matching
+
+Build a data preparation function that re-parses the source policy document to recover full chunk text, then locates each extracted evidence quote within its corresponding chunk using normalized substring matching with a stdlib fuzzy fallback. Returns a structured dict for template consumption: chunks with positioned annotations (start/end character offsets), a summary with counts, and extraction metadata. No ground truth handling in this task.
+
+Unit tests using plain text files to avoid the docling dependency: exact matching, fuzzy matching, overlapping spans, unmatched spans, zero-risk case, and chunk index alignment validation.
+
+No pipeline changes. No new dependencies.
+
+**PR scope:** New `annotate.py` module + tests.
+
+---
+
+### Task 2: Document-centric HTML template with sidebar navigation
+
+Create a self-contained HTML report that renders the source document text chunk-by-chunk with risk evidence highlighted inline. Same tech stack and pattern as the existing risk extraction report (Alpine.js + Tailwind CDN, embedded JSON, no server needed).
+
+Layout: summary banner with policy name and evidence span counts, sticky left sidebar with a risk index and jump-to links (filterable by risk ID or taxonomy), main content area with document text grouped by section. Evidence spans are highlighted and color-coded by taxonomy. Hover shows a tooltip with risk metadata. Click opens an expandable panel with risk description, grounding confidence, evidence quote, and causal chain fields. Dark mode support. No ground truth rendering in this task.
+
+**PR scope:** Template file only. No Python changes beyond what Task 1 already provides.
+
+---
+
+### Task 3: CLI command and report builder wiring
+
+Wire the data preparation layer and the HTML template into the CLI.
+
+Add a report builder function following the same pattern as the existing risk extraction report builder. Add a new `annotate` CLI command that takes a run directory and source document path, produces the annotation HTML report, and prints a summary to stdout. Also hook into the existing `extract` command so every extraction run automatically produces the annotation report alongside the risk extraction report.
+
+**PR scope:** Report builder function, CLI command, extraction hook, integration tests.
+
+---
+
+### Task 4: Ground truth comparison overlay
+
+Add ground truth comparison mode across the data layer, template, and CLI.
+
+Data layer: accept an optional ground truth YAML, call the existing evaluation function to classify each risk as matched or spurious, and populate a missed-risks list (GT risks with no extraction evidence — sidebar only, not inline).
+
+Template: when GT data is present, re-color annotations — matched = green with checkmark, spurious = yellow with warning icon. Show missed risks in the sidebar with a red indicator. Add GT metrics (matched/spurious/missed counts, precision, recall, F1) to the summary banner.
+
+CLI: add a ground truth flag to the annotate command. Add a source document flag to the eval command so it can regenerate the annotation report with the GT overlay.
+
+**PR scope:** Changes across `annotate.py`, template, CLI, and tests.
+
+---
+
+## Summary of deliverables per task
+
+| Task | PR Output | Depends On |
+|------|-----------|------------|
+| 1 | Data preparation module + unit tests | Nothing |
+| 2 | HTML template | Task 1 (data shape) |
+| 3 | Report builder + CLI command + integration | Tasks 1 & 2 |
+| 4 | Ground truth comparison overlay | Tasks 1-3 |
+
+## Commands reference
+
+```bash
+# Install / sync
+uv sync
+
+# Run fast tests
+uv run pytest -rs -m "not slow"
+
+# Format + lint + type check
+uv run ruff format src/ tests/ && uv run ruff check src/ tests/ && uv run mypy src/asago_policy_mapper/
+
+# Run extraction (produces both reports)
+uv run asago-policy-mapper extract policy.pdf -o output/ --base-url http://... --model gemma4-26b-a4b-it
+
+# Generate annotation view standalone
+uv run asago-policy-mapper annotate output/ policy.pdf
+
+# Generate annotation view with GT comparison
+uv run asago-policy-mapper annotate output/ policy.pdf --ground-truth evals/ground_truth/policy.yaml
+
+# Run eval with annotation view
+uv run asago-policy-mapper eval output/ --source-document policy.pdf
+```

--- a/src/asago_policy_mapper/cli.py
+++ b/src/asago_policy_mapper/cli.py
@@ -287,6 +287,66 @@ def extract(
     report_path = build_risk_extraction_report(result_data, output / "risk-extraction.html")
     typer.echo(f"Report written to {report_path}")
 
+    from asago_policy_mapper.extract.annotate import prepare_annotation_data
+    from asago_policy_mapper.extract.report import build_annotation_report
+
+    annotation_data = prepare_annotation_data(result_data, policy_files[0], ocr=ocr, chunk_max_tokens=chunk_max_tokens)
+    ann_path = build_annotation_report(annotation_data, output / "risk-annotation.html")
+    typer.echo(f"Annotation view written to {ann_path}")
+
+
+@app.command(name="annotate")
+def annotate_cmd(
+    run_dir: Path = typer.Argument(..., help="Directory containing risk-extraction.json"),
+    source_document: Path = typer.Argument(..., help="Original policy document (PDF, DOCX, etc.)"),
+    ground_truth: Path = typer.Option(None, "--ground-truth", "-g", help="Ground truth YAML for comparison mode"),
+    ocr: bool = typer.Option(False, "--ocr", help="Enable OCR for document conversion"),
+    chunk_max_tokens: int = typer.Option(512, "--chunk-max-tokens", help="Max tokens per chunk"),
+):
+    """Generate a document-centric annotation view from a completed extraction run."""
+    json_path = run_dir / "risk-extraction.json"
+    yaml_path = run_dir / "risk-extraction.yaml"
+    if json_path.exists():
+        extracted_path = json_path
+    elif yaml_path.exists():
+        extracted_path = yaml_path
+    else:
+        typer.echo(f"Error: no risk-extraction.json or .yaml found in {run_dir}", err=True)
+        raise typer.Exit(1)
+
+    extraction_data = (
+        json.loads(extracted_path.read_text())
+        if extracted_path.suffix == ".json"
+        else yaml.safe_load(extracted_path.read_text())
+    )
+
+    from asago_policy_mapper.extract.annotate import prepare_annotation_data
+    from asago_policy_mapper.extract.report import build_annotation_report
+
+    annotation_data = prepare_annotation_data(
+        extraction_data,
+        source_document,
+        ground_truth_path=ground_truth,
+        extracted_path=extracted_path,
+        ocr=ocr,
+        chunk_max_tokens=chunk_max_tokens,
+    )
+    ann_path = build_annotation_report(annotation_data, run_dir / "risk-annotation.html")
+
+    summary = annotation_data["summary"]
+    typer.echo(f"Annotation view: {summary['total_risks']} risks, {summary['total_evidence_spans']} evidence spans")
+    typer.echo(f"  Matched: {summary['matched_spans']}, Unmatched: {summary['unmatched_spans']}")
+    if annotation_data.get("eval"):
+        ev = annotation_data["eval"]
+        typer.echo(
+            f"  GT: {ev['matched']} matched, {len(ev['spurious'])} spurious, {len(ev['missing'])} missing"
+            f" — P={ev['precision']:.3f} R={ev['recall']:.3f} F1={ev['f1']:.3f}"
+        )
+        revised_dir = run_dir / "revised_gt"
+        revised_dir.mkdir(exist_ok=True)
+        typer.echo(f"  Save revised GT to: {revised_dir}/")
+    typer.echo(f"  Written to {ann_path}")
+
 
 @app.command(name="eval")
 def eval_cmd(

--- a/src/asago_policy_mapper/extract/annotate.py
+++ b/src/asago_policy_mapper/extract/annotate.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import difflib
+import re
+import unicodedata
+from pathlib import Path
+
+from asago_policy_mapper.extract.parse import Chunk, chunk_documents, parse_document
+
+
+def _normalize(text: str) -> str:
+    text = unicodedata.normalize("NFKC", text)
+    text = text.replace("’", "'").replace("‘", "'")
+    text = text.replace("“", '"').replace("”", '"')
+    text = text.replace("—", "-").replace("–", "-")
+    text = text.replace(" ", " ")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _find_span_in_chunk(
+    evidence_text: str,
+    chunk_text: str,
+    fuzzy_threshold: float = 0.8,
+) -> tuple[int, int, bool]:
+    """Locate evidence_text within chunk_text, return (start, end, is_fuzzy).
+
+    Tries exact substring first, then normalized, then fuzzy via
+    SequenceMatcher.find_longest_match. Returns (0, 0, False) on failure.
+    """
+    if evidence_text in chunk_text:
+        start = chunk_text.index(evidence_text)
+        return start, start + len(evidence_text), False
+
+    norm_ev = _normalize(evidence_text)
+    norm_chunk = _normalize(chunk_text)
+
+    if norm_ev in norm_chunk:
+        idx = norm_chunk.index(norm_ev)
+        start, end = _map_normalized_offsets(chunk_text, norm_chunk, idx, idx + len(norm_ev))
+        return start, end, False
+
+    sm = difflib.SequenceMatcher(None, norm_chunk, norm_ev, autojunk=False)
+    ratio = sm.ratio()
+
+    if ratio >= fuzzy_threshold:
+        blocks = sm.get_matching_blocks()
+        if blocks:
+            first_a = blocks[0].a
+            last = blocks[-2] if len(blocks) > 1 else blocks[0]
+            last_a_end = last.a + last.size
+            start, end = _map_normalized_offsets(chunk_text, norm_chunk, first_a, last_a_end)
+            return start, end, True
+
+    return 0, 0, False
+
+
+def _map_normalized_offsets(original: str, normalized: str, norm_start: int, norm_end: int) -> tuple[int, int]:
+    """Map character offsets in normalized text back to the original text.
+
+    Walks both strings in parallel, tracking how positions correspond.
+    Falls back to proportional mapping if the walk fails.
+    """
+    orig_start = 0
+    found_start = False
+
+    norm_idx = 0
+    orig_idx = 0
+
+    while norm_idx < len(normalized) and orig_idx < len(original):
+        if norm_idx == norm_start and not found_start:
+            orig_start = orig_idx
+            found_start = True
+        if norm_idx == norm_end:
+            orig_end = orig_idx
+            return orig_start, orig_end
+
+        norm_char = normalized[norm_idx]
+        orig_char = original[orig_idx]
+
+        if norm_char == orig_char:
+            norm_idx += 1
+            orig_idx += 1
+        elif orig_char in (" ", "\t", "\n", "\r", " "):
+            orig_idx += 1
+        else:
+            norm_idx += 1
+            orig_idx += 1
+
+    if not found_start:
+        ratio = len(original) / max(len(normalized), 1)
+        orig_start = int(norm_start * ratio)
+    orig_end = min(len(original), orig_idx)
+
+    return orig_start, orig_end
+
+
+def _locate_evidence(
+    evidence_text: str,
+    chunk_index: int,
+    chunks: list[Chunk],
+    fuzzy_threshold: float = 0.8,
+) -> tuple[int, int, int, bool]:
+    """Find evidence_text in chunks, return (chunk_index, start, end, is_fuzzy).
+
+    Strategy: try the hinted chunk_index first, then scan all chunks.
+    Returns (chunk_index, 0, 0, False) if not found anywhere.
+    """
+    if 0 <= chunk_index < len(chunks):
+        start, end, is_fuzzy = _find_span_in_chunk(evidence_text, chunks[chunk_index].text, fuzzy_threshold)
+        if end > start:
+            return chunk_index, start, end, is_fuzzy
+
+    for i, chunk in enumerate(chunks):
+        if i == chunk_index:
+            continue
+        start, end, is_fuzzy = _find_span_in_chunk(evidence_text, chunk.text, fuzzy_threshold)
+        if end > start:
+            return i, start, end, is_fuzzy
+
+    return chunk_index if 0 <= chunk_index < len(chunks) else 0, 0, 0, False
+
+
+def _overlaps_existing(
+    risk_id: str,
+    chunk_index: int,
+    start: int,
+    end: int,
+    seen: list[tuple[str, int, int, int]],
+) -> bool:
+    """Check if this span overlaps significantly with an existing span for the same risk."""
+    for s_rid, s_ci, s_start, s_end in seen:
+        if s_rid != risk_id or s_ci != chunk_index:
+            continue
+        overlap_start = max(start, s_start)
+        overlap_end = min(end, s_end)
+        if overlap_end <= overlap_start:
+            continue
+        overlap_len = overlap_end - overlap_start
+        shorter_len = min(end - start, s_end - s_start)
+        if shorter_len > 0 and overlap_len / shorter_len >= 0.5:
+            return True
+    return False
+
+
+def prepare_annotation_data(
+    extraction_data: dict,
+    source_document: Path,
+    ground_truth_path: Path | None = None,
+    extracted_path: Path | None = None,
+    ocr: bool = False,
+    chunk_max_tokens: int = 512,
+) -> dict:
+    """Prepare annotation data for the document-centric HTML report.
+
+    Re-parses the source document, locates evidence spans within chunk text,
+    and returns a dict structured for template rendering. When ground_truth_path
+    is provided, classifies each risk as matched/spurious and lists missed risks.
+    """
+    doc = parse_document(source_document, ocr=ocr)
+    chunks = chunk_documents([doc], max_tokens=chunk_max_tokens)
+
+    chunk_annotations: dict[int, list[dict]] = {i: [] for i in range(len(chunks))}
+    seen_spans: list[tuple[str, int, int, int]] = []
+
+    total_evidence = 0
+    matched_spans = 0
+    unmatched_spans = 0
+    evidence_id_counter = 0
+
+    for risk in extraction_data.get("risks", []):
+        for ev in risk.get("evidence", []):
+            total_evidence += 1
+            ev_text = ev.get("text", "")
+            hint_ci = ev.get("chunk_index", 0)
+
+            ci, start, end, is_fuzzy = _locate_evidence(ev_text, hint_ci, chunks)
+
+            if end > start:
+                if _overlaps_existing(risk.get("risk_id", ""), ci, start, end, seen_spans):
+                    continue
+                seen_spans.append((risk.get("risk_id", ""), ci, start, end))
+                matched_spans += 1
+            else:
+                unmatched_spans += 1
+
+            evidence_id_counter += 1
+            annotation = {
+                "evidence_id": f"ev-{evidence_id_counter}",
+                "start": start,
+                "end": end,
+                "evidence_text": ev_text,
+                "matched_in_text": end > start,
+                "is_fuzzy": is_fuzzy,
+                "risk_id": risk.get("risk_id", ""),
+                "risk_name": risk.get("risk_name", ""),
+                "risk_description": risk.get("risk_description", ""),
+                "taxonomy": risk.get("taxonomy", ""),
+                "confidence": risk.get("confidence", 0.0),
+                "grounding_confidence": risk.get("grounding_confidence", ""),
+                "causal_chain": {
+                    "threat": risk.get("threat"),
+                    "threat_source": risk.get("threat_source"),
+                    "vulnerability": risk.get("vulnerability"),
+                    "consequence": risk.get("consequence"),
+                    "impact": risk.get("impact"),
+                },
+            }
+            chunk_annotations[ci].append(annotation)
+
+    annotated_chunks = []
+    for i, chunk in enumerate(chunks):
+        annotations = sorted(chunk_annotations.get(i, []), key=lambda a: a["start"])
+        annotated_chunks.append(
+            {
+                "index": chunk.index,
+                "text": chunk.text,
+                "page": chunk.page,
+                "section": chunk.section,
+                "annotations": annotations,
+            }
+        )
+
+    total_risks = len(extraction_data.get("risks", []))
+
+    eval_result = None
+    missed_risks: list[dict] = []
+    gt_matched_ids: set[str] = set()
+    gt_spurious_ids: set[str] = set()
+    gt_risk_ids: list[str] = []
+    gt_filename = ""
+
+    if ground_truth_path is not None and extracted_path is not None:
+        import yaml as _yaml
+
+        from asago_policy_mapper.evals.eval import evaluate_extraction
+
+        eval_result = evaluate_extraction(
+            ground_truth_path,
+            extracted_path,
+            policy_name=ground_truth_path.stem,
+        )
+        gt_matched_ids = set(eval_result.get("matched_ids", []))
+        gt_spurious_ids = set(eval_result.get("spurious", []))
+        gt_filename = ground_truth_path.name
+
+        gt_data = _yaml.safe_load(ground_truth_path.read_text())
+        if "risks" in gt_data:
+            gt_risk_ids = [r["id"] for r in gt_data["risks"]]
+        else:
+            gt_risk_ids = [str(rid) for rid in gt_data.get("risk_ids", [])]
+
+        for risk_id in eval_result.get("missing", []):
+            missed_risks.append({"risk_id": risk_id})
+
+        for chunk_data in annotated_chunks:
+            for ann in chunk_data["annotations"]:  # type: ignore[attr-defined]
+                rid = ann["risk_id"]
+                if rid in gt_matched_ids:
+                    ann["classification"] = "matched"
+                elif rid in gt_spurious_ids:
+                    ann["classification"] = "spurious"
+                else:
+                    ann["classification"] = None
+
+    return {
+        "chunks": annotated_chunks,
+        "summary": {
+            "total_risks": total_risks,
+            "total_evidence_spans": total_evidence,
+            "matched_spans": matched_spans,
+            "unmatched_spans": unmatched_spans,
+            "total_chunks": len(chunks),
+            "gt_matched": len(gt_matched_ids) if eval_result else None,
+            "gt_spurious": len(gt_spurious_ids) if eval_result else None,
+            "gt_missing": len(missed_risks) if eval_result else None,
+        },
+        "eval": eval_result,
+        "missed_risks": missed_risks,
+        "gt_risk_ids": gt_risk_ids,
+        "gt_filename": gt_filename,
+        "source_document": source_document.name,
+        "metadata": extraction_data.get("metadata", {}),
+    }

--- a/src/asago_policy_mapper/extract/report.py
+++ b/src/asago_policy_mapper/extract/report.py
@@ -37,3 +37,16 @@ def build_risk_extraction_report(data: dict, output_path: Path) -> Path:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(html)
     return output_path
+
+
+def build_annotation_report(data: dict, output_path: Path) -> Path:
+    html = (
+        (TEMPLATE_DIR / "annotation_report_template.html")
+        .read_text()
+        .replace("__REPORT_DATA__", json.dumps(data, default=str))
+    )
+    html = html.replace("</head>", _get_dark_snippet() + "\n</head>", 1)
+    html = html.replace("</body>", _DARK_TOGGLE + "\n</body>", 1)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(html)
+    return output_path

--- a/src/asago_policy_mapper/templates/annotation_report_template.html
+++ b/src/asago_policy_mapper/templates/annotation_report_template.html
@@ -1,0 +1,833 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Annotation View — Risk Extraction</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>
+    :root { color-scheme: light; }
+    [x-cloak] { display: none !important; }
+
+    /* Taxonomy color palette — 12 distinguishable hues */
+    .tax-0  { background: rgba(59,130,246,0.18); border-left: 3px solid #3b82f6; }
+    .tax-1  { background: rgba(16,185,129,0.18); border-left: 3px solid #10b981; }
+    .tax-2  { background: rgba(245,158,11,0.18); border-left: 3px solid #f59e0b; }
+    .tax-3  { background: rgba(239,68,68,0.18);  border-left: 3px solid #ef4444; }
+    .tax-4  { background: rgba(139,92,246,0.18); border-left: 3px solid #8b5cf6; }
+    .tax-5  { background: rgba(236,72,153,0.18); border-left: 3px solid #ec4899; }
+    .tax-6  { background: rgba(20,184,166,0.18); border-left: 3px solid #14b8a6; }
+    .tax-7  { background: rgba(249,115,22,0.18); border-left: 3px solid #f97316; }
+    .tax-8  { background: rgba(99,102,241,0.18); border-left: 3px solid #6366f1; }
+    .tax-9  { background: rgba(34,197,94,0.18);  border-left: 3px solid #22c55e; }
+    .tax-10 { background: rgba(168,85,247,0.18); border-left: 3px solid #a855f7; }
+    .tax-11 { background: rgba(6,182,212,0.18);  border-left: 3px solid #06b6d4; }
+
+    /* Highlight mark */
+    mark.annotation {
+      padding: 1px 2px;
+      border-radius: 3px;
+      cursor: pointer;
+      position: relative;
+    }
+    mark.annotation:hover { filter: brightness(0.9); }
+    mark.annotation.ring-highlight {
+      outline: 3px solid #3b82f6;
+      outline-offset: 1px;
+    }
+
+    mark.unmatched {
+      background: rgba(156,163,175,0.25);
+      border-left: 3px solid #9ca3af;
+      border-bottom: 2px dashed #9ca3af;
+    }
+
+    /* GT classification colors */
+    mark.gt-matched {
+      background: rgba(34,197,94,0.22) !important;
+      border-left: 3px solid #22c55e !important;
+    }
+    mark.gt-spurious {
+      background: rgba(245,158,11,0.22) !important;
+      border-left: 3px solid #f59e0b !important;
+    }
+    .dark mark.gt-matched {
+      background: rgba(34,197,94,0.30) !important;
+    }
+    .dark mark.gt-spurious {
+      background: rgba(245,158,11,0.30) !important;
+    }
+
+    /* Sidebar */
+    .sidebar-item { transition: background 0.15s; }
+    .sidebar-item:hover { background: rgba(0,0,0,0.04); }
+    .sidebar-item.active { background: rgba(59,130,246,0.1); border-left: 3px solid #3b82f6; }
+
+    /* Section header — offset below the main sticky header (64px) */
+    .section-header {
+      position: sticky;
+      top: 64px;
+      z-index: 5;
+      backdrop-filter: blur(8px);
+    }
+
+    /* Scroll offset for anchor targets */
+    html { scroll-padding-top: 80px; }
+
+    /* Dark overrides for marks */
+    .dark mark.annotation { filter: brightness(1.1); }
+    .dark .sidebar-item:hover { background: rgba(255,255,255,0.06); }
+    .dark .sidebar-item.active { background: rgba(96,165,250,0.15); border-left-color: #60a5fa; }
+    .dark mark.annotation.ring-highlight { outline-color: #60a5fa; }
+
+    /* Table rendering for docling tables */
+    .chunk-table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 8px 0;
+      font-size: 13px;
+    }
+    .chunk-table th, .chunk-table td {
+      border: 1px solid #e5e7eb;
+      padding: 4px 8px;
+      text-align: left;
+    }
+    .chunk-table th {
+      background: #f3f4f6;
+      font-weight: 600;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+    }
+    .dark .chunk-table th { background: #374151; }
+    .dark .chunk-table th, .dark .chunk-table td { border-color: #4b5563; }
+
+    /* Occurrence navigator */
+    .occ-nav {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      margin-left: 8px;
+      font-size: 11px;
+    }
+    .occ-nav button {
+      width: 20px;
+      height: 20px;
+      border-radius: 4px;
+      border: 1px solid #d1d5db;
+      background: white;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 10px;
+      color: #6b7280;
+    }
+    .occ-nav button:hover { background: #f3f4f6; }
+    .dark .occ-nav button { background: #374151; border-color: #4b5563; color: #9ca3af; }
+    .dark .occ-nav button:hover { background: #4b5563; }
+  </style>
+</head>
+<body class="bg-gray-50 text-gray-900 min-h-screen">
+
+<div x-data="annotationApp()" x-cloak class="flex min-h-screen">
+
+  <!-- Sidebar -->
+  <aside class="w-72 bg-white border-r border-gray-200 flex flex-col fixed h-full overflow-hidden z-20">
+    <!-- Sidebar header -->
+    <div class="p-4 border-b border-gray-200">
+      <h2 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-2">Risk Index</h2>
+      <input
+        type="text"
+        x-model="sidebarFilter"
+        placeholder="Filter by risk ID or taxonomy..."
+        class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+      />
+      <div class="mt-2 flex gap-1 flex-wrap">
+        <template x-for="tax in taxonomies" :key="tax">
+          <button
+            @click="toggleTaxFilter(tax)"
+            :class="taxFilterActive(tax) ? 'bg-blue-100 text-blue-800 border-blue-300' : 'bg-gray-100 text-gray-600 border-gray-200'"
+            class="text-xs px-2 py-0.5 rounded border cursor-pointer"
+            x-text="tax"
+          ></button>
+        </template>
+      </div>
+    </div>
+
+    <!-- Risk list -->
+    <div class="flex-1 overflow-y-auto">
+      <template x-for="risk in filteredRisks()" :key="risk.risk_id">
+        <div
+          class="sidebar-item px-4 py-2 border-b border-gray-100 cursor-pointer"
+          :class="{ 'active': selectedRisk === risk.risk_id }"
+          @click="jumpToRisk(risk.risk_id)"
+        >
+          <div class="flex items-center justify-between">
+            <div class="text-sm font-medium text-gray-800 truncate flex-1" x-text="risk.risk_name"></div>
+            <!-- Occurrence navigator -->
+            <template x-if="selectedRisk === risk.risk_id">
+              <div class="occ-nav" @click.stop>
+                <template x-if="occurrenceEls.length > 1">
+                  <button @click="prevOccurrence()" title="Previous">&larr;</button>
+                </template>
+                <span class="text-gray-500" x-text="occurrenceEls.length > 0 ? (currentOccIdx + 1) + '/' + occurrenceEls.length : '0 matched'"></span>
+                <template x-if="occurrenceEls.length > 1">
+                  <button @click="nextOccurrence()" title="Next">&rarr;</button>
+                </template>
+              </div>
+            </template>
+          </div>
+          <div class="text-xs text-gray-500 mt-0.5 flex items-center gap-1">
+            <span x-text="risk.risk_id"></span>
+            <span class="mx-1">&middot;</span>
+            <span x-text="risk.taxonomy"></span>
+            <template x-if="gtMode && risk.classification">
+              <span class="ml-1 inline-flex items-center gap-1">
+                <span
+                  class="text-xs px-1.5 py-0 rounded font-semibold"
+                  :class="risk.classification === 'matched' ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'"
+                  x-text="risk.classification === 'matched' ? 'TP' : 'FP'"
+                ></span>
+                <span
+                  class="text-xs px-1.5 py-0 rounded"
+                  :class="risk.classification === 'matched' ? 'bg-green-50 text-green-600' : 'bg-amber-50 text-amber-600'"
+                  x-text="risk.classification === 'matched' ? '&#10003; in GT' : '? review'"
+                ></span>
+              </span>
+            </template>
+          </div>
+          <div class="text-xs text-gray-400 mt-0.5 flex items-center justify-between">
+            <span>
+              <span x-text="risk.evidence_count + ' evidence span' + (risk.evidence_count !== 1 ? 's' : '')"></span>
+              <span class="mx-1">&middot;</span>
+              <span x-text="(risk.confidence * 100).toFixed(0) + '%'"></span>
+            </span>
+            <!-- GT curation button -->
+            <template x-if="gtMode && risk.classification === 'spurious'">
+              <button
+                @click.stop="toggleGtChange(risk.risk_id, 'add')"
+                class="text-xs px-1.5 py-0 rounded cursor-pointer"
+                :class="gtChanges[risk.risk_id] === 'add' ? 'bg-green-200 text-green-800' : 'bg-gray-200 text-gray-600 hover:bg-green-100'"
+                x-text="gtChanges[risk.risk_id] === 'add' ? '&#10003; added' : '+ add to GT'"
+              ></button>
+            </template>
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <!-- Missed risks -->
+    <template x-if="gtMode && data.missed_risks && data.missed_risks.length > 0">
+      <div class="border-t border-gray-200">
+        <div class="px-4 py-2 bg-red-50 text-xs font-semibold text-red-700 uppercase">
+          In GT but not extracted &mdash; <span x-text="data.missed_risks.filter(m => gtChanges[m.risk_id] !== 'remove').length"></span>
+        </div>
+        <div class="max-h-48 overflow-y-auto">
+          <template x-for="missed in data.missed_risks" :key="missed.risk_id">
+            <div class="px-4 py-1.5 border-b border-gray-100 text-xs flex items-center justify-between">
+              <span class="flex items-center gap-1">
+                <span class="px-1.5 py-0 rounded font-semibold bg-red-100 text-red-700">FN</span>
+                <span :class="gtChanges[missed.risk_id] === 'remove' ? 'line-through text-gray-400' : 'text-red-600'" x-text="missed.risk_id"></span>
+              </span>
+              <button
+                @click.stop="toggleGtChange(missed.risk_id, 'remove')"
+                class="text-xs px-1.5 py-0 rounded cursor-pointer"
+                :class="gtChanges[missed.risk_id] === 'remove' ? 'bg-red-200 text-red-800' : 'bg-gray-200 text-gray-600 hover:bg-red-100'"
+                x-text="gtChanges[missed.risk_id] === 'remove' ? '&#10003; removed' : '- remove'"
+              ></button>
+            </div>
+          </template>
+        </div>
+      </div>
+    </template>
+
+    <!-- Sidebar footer -->
+    <div class="p-3 border-t border-gray-200 bg-gray-50 text-xs text-gray-500">
+      <span x-text="filteredRisks().length + '/' + riskIndex.length + ' risks'"></span>
+      <template x-if="gtMode && Object.keys(gtChanges).length > 0">
+        <button
+          @click="exportRevisedGT()"
+          class="ml-2 px-2 py-0.5 bg-blue-600 text-white rounded text-xs cursor-pointer hover:bg-blue-700"
+          x-text="'Export revised GT (' + Object.keys(gtChanges).length + ' changes)'"
+        ></button>
+      </template>
+    </div>
+  </aside>
+
+  <!-- Main content -->
+  <main class="flex-1 ml-72">
+    <!-- Summary banner -->
+    <header class="bg-white border-b border-gray-200 px-6 sticky top-0 z-10" :style="hasGT ? 'height:auto; padding:12px 24px' : 'height:64px; padding:16px 24px'">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-xl font-bold text-gray-900">Annotation View</h1>
+          <p class="text-sm text-gray-500 mt-0.5" x-text="'Policy Document: ' + (data.source_document || 'unknown')"></p>
+        </div>
+        <div class="flex items-center gap-6 text-sm">
+          <!-- GT toggle -->
+          <template x-if="hasGT">
+            <div class="flex items-center gap-2 border-r border-gray-200 pr-6">
+              <label class="text-xs text-gray-600 font-medium">View:</label>
+              <button
+                @click="gtMode = false"
+                :class="!gtMode ? 'bg-blue-100 text-blue-800 border-blue-300' : 'bg-gray-100 text-gray-600 border-gray-200'"
+                class="text-xs px-3 py-1 rounded border cursor-pointer"
+              >Extraction</button>
+              <button
+                @click="gtMode = true"
+                :class="gtMode ? 'bg-blue-100 text-blue-800 border-blue-300' : 'bg-gray-100 text-gray-600 border-gray-200'"
+                class="text-xs px-3 py-1 rounded border cursor-pointer"
+              >Ground Truth</button>
+            </div>
+          </template>
+
+          <div class="text-center">
+            <div class="text-2xl font-bold text-blue-600" x-text="data.summary.total_risks"></div>
+            <div class="text-gray-500">Risks</div>
+          </div>
+
+          <!-- Taxonomy mode stats -->
+          <template x-if="!gtMode">
+            <div class="flex gap-6">
+              <div class="text-center">
+                <div class="text-2xl font-bold text-green-600" x-text="data.summary.matched_spans"></div>
+                <div class="text-gray-500">Matched</div>
+              </div>
+              <div class="text-center" x-show="data.summary.unmatched_spans > 0">
+                <div class="text-2xl font-bold text-amber-500" x-text="data.summary.unmatched_spans"></div>
+                <div class="text-gray-500">Unmatched</div>
+              </div>
+              <div class="text-center">
+                <div class="text-2xl font-bold text-gray-600" x-text="data.summary.total_chunks"></div>
+                <div class="text-gray-500">Chunks</div>
+              </div>
+            </div>
+          </template>
+
+          <!-- GT mode stats -->
+          <template x-if="gtMode && hasGT">
+            <div class="flex gap-6">
+              <div class="text-center">
+                <div class="text-2xl font-bold text-green-600" x-text="data.summary.gt_matched"></div>
+                <div class="text-gray-500">TP <span class="text-gray-400">confirmed</span></div>
+              </div>
+              <div class="text-center">
+                <div class="text-2xl font-bold text-amber-500" x-text="data.summary.gt_spurious"></div>
+                <div class="text-gray-500">FP <span class="text-gray-400">review</span></div>
+              </div>
+              <div class="text-center">
+                <div class="text-2xl font-bold text-red-500" x-text="data.summary.gt_missing"></div>
+                <div class="text-gray-500">FN <span class="text-gray-400">missing</span></div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold text-gray-700" x-text="'P=' + data.eval.precision.toFixed(2) + ' R=' + data.eval.recall.toFixed(2)"></div>
+                <div class="text-gray-500" x-text="'F1=' + data.eval.f1.toFixed(3)"></div>
+              </div>
+            </div>
+          </template>
+        </div>
+      </div>
+    </header>
+
+    <!-- Document body -->
+    <div class="px-6 py-4 max-w-4xl" @click="handleAnnotationClick($event)">
+      <template x-for="(section, sIdx) in groupedSections" :key="sIdx">
+        <div class="mb-6">
+          <!-- Section heading -->
+          <div
+            class="section-header bg-gray-100 px-4 py-2 rounded-t-md mb-1 flex items-center justify-between"
+            :id="'section-' + sIdx"
+          >
+            <h3 class="text-sm font-semibold text-gray-700" x-text="section.title || 'Untitled Section'"></h3>
+            <span
+              class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full"
+              x-text="section.riskIds.size + ' unique risk' + (section.riskIds.size !== 1 ? 's' : '')"
+              x-show="section.riskIds.size > 0"
+            ></span>
+          </div>
+
+          <!-- Chunks in this section -->
+          <template x-for="chunk in section.chunks" :key="chunk.index">
+            <div
+              class="bg-white border border-gray-200 rounded-b-md px-5 py-4 mb-2 leading-relaxed text-gray-800"
+              :id="'chunk-' + chunk.index"
+            >
+              <!-- Page indicator -->
+              <div x-show="chunk.page" class="text-xs text-gray-400 mb-2">
+                Page <span x-text="chunk.page"></span>
+              </div>
+
+              <!-- Chunk text with annotations -->
+              <div class="text-sm" x-html="renderChunk(chunk, gtMode)"></div>
+
+              <!-- Unmatched annotations shown below -->
+              <template x-for="ann in chunk.annotations.filter(a => !a.matched_in_text)" :key="ann.risk_id + '-unmatched-' + ann.evidence_text.slice(0,20)">
+                <div class="mt-3 p-3 bg-gray-50 border border-gray-200 rounded text-sm">
+                  <div class="flex items-center gap-2 mb-1">
+                    <span class="text-amber-500 text-xs font-semibold">&starf; UNMATCHED</span>
+                    <span class="text-gray-600 font-medium" x-text="ann.risk_name"></span>
+                    <span class="text-gray-400 text-xs" x-text="ann.risk_id"></span>
+                  </div>
+                  <div class="text-gray-500 text-xs italic" x-text="'\"' + ann.evidence_text.slice(0, 200) + (ann.evidence_text.length > 200 ? '...' : '') + '\"'"></div>
+                </div>
+              </template>
+            </div>
+          </template>
+        </div>
+      </template>
+    </div>
+  </main>
+
+  <!-- Detail panel (popover) -->
+  <div
+    x-show="activeAnnotations.length > 0"
+    x-transition
+    @click.outside="activeAnnotations = []"
+    @keydown.escape.window="activeAnnotations = []"
+    class="fixed bottom-4 right-4 w-96 bg-white border border-gray-200 rounded-lg shadow-xl z-30 max-h-[60vh] overflow-y-auto"
+  >
+    <div class="p-4">
+      <div class="flex items-center justify-between mb-3">
+        <div class="text-xs text-gray-500" x-text="activeAnnotations.length + ' risk' + (activeAnnotations.length !== 1 ? 's' : '') + ' on this span'"></div>
+        <button @click="activeAnnotations = []" class="text-gray-400 hover:text-gray-600 text-lg leading-none">&times;</button>
+      </div>
+
+      <template x-for="(ann, aIdx) in activeAnnotations" :key="ann.risk_id">
+        <div :class="aIdx > 0 ? 'mt-4 pt-4 border-t border-gray-200' : ''">
+          <div class="mb-2">
+            <h4 class="font-semibold text-gray-900" x-text="ann.risk_name"></h4>
+            <p class="text-xs text-gray-500 mt-0.5" x-text="ann.risk_id"></p>
+          </div>
+
+          <!-- Taxonomy & confidence -->
+          <div class="flex gap-2 mb-2 flex-wrap">
+            <span class="text-xs px-2 py-0.5 rounded bg-blue-50 text-blue-700" x-text="ann.taxonomy"></span>
+            <span class="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-700" x-text="(ann.confidence * 100).toFixed(0) + '% confidence'"></span>
+            <span
+              class="text-xs px-2 py-0.5 rounded"
+              :class="{
+                'bg-green-50 text-green-700': ann.grounding_confidence === 'high',
+                'bg-amber-50 text-amber-700': ann.grounding_confidence === 'medium',
+                'bg-red-50 text-red-700': ann.grounding_confidence === 'low'
+              }"
+              x-text="ann.grounding_confidence + ' grounding'"
+            ></span>
+          </div>
+
+          <!-- Description -->
+          <p class="text-sm text-gray-600 mb-2" x-text="ann.risk_description"></p>
+
+          <!-- Evidence quote -->
+          <div class="mb-2">
+            <div class="text-xs font-semibold text-gray-500 uppercase mb-1">Evidence</div>
+            <div class="text-sm text-gray-700 bg-gray-50 p-2 rounded border-l-2 border-gray-300 italic" x-text="ann.evidence_text"></div>
+          </div>
+
+          <!-- Fuzzy match warning -->
+          <div x-show="ann.is_fuzzy" class="mb-2 text-xs text-amber-600 flex items-center gap-1">
+            <span>&starf;</span> Fuzzy match
+          </div>
+
+          <!-- Causal chain -->
+          <template x-if="hasCausalChain(ann)">
+            <div class="mb-1">
+              <div class="text-xs font-semibold text-gray-500 uppercase mb-1">Causal Chain</div>
+              <div class="space-y-1">
+                <template x-for="field in causalChainFields(ann)" :key="field.label">
+                  <div class="flex items-start gap-2 text-sm">
+                    <span class="text-xs font-medium text-gray-500 w-24 flex-shrink-0 pt-0.5" x-text="field.label"></span>
+                    <span class="text-gray-700" x-text="field.value"></span>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </template>
+        </div>
+      </template>
+    </div>
+  </div>
+</div>
+
+<script>
+const data = __REPORT_DATA__;
+
+function annotationApp() {
+  const taxonomyColorMap = {};
+  let taxIdx = 0;
+  (data.chunks || []).forEach(c => {
+    (c.annotations || []).forEach(a => {
+      if (a.taxonomy && !(a.taxonomy in taxonomyColorMap)) {
+        taxonomyColorMap[a.taxonomy] = taxIdx % 12;
+        taxIdx++;
+      }
+    });
+  });
+
+  const riskMap = {};
+  const riskEvidenceIds = {};  // risk_id → [evidence_id, ...]
+  (data.chunks || []).forEach(c => {
+    (c.annotations || []).forEach(a => {
+      if (!a.matched_in_text) return;
+      if (!riskMap[a.risk_id]) {
+        riskMap[a.risk_id] = {
+          risk_id: a.risk_id,
+          risk_name: a.risk_name,
+          taxonomy: a.taxonomy,
+          confidence: a.confidence,
+          classification: a.classification || null,
+          evidence_count: 0,
+        };
+        riskEvidenceIds[a.risk_id] = [];
+      }
+      riskMap[a.risk_id].evidence_count++;
+      if (a.evidence_id && !riskEvidenceIds[a.risk_id].includes(a.evidence_id)) {
+        riskEvidenceIds[a.risk_id].push(a.evidence_id);
+      }
+    });
+  });
+  const riskIndex = Object.values(riskMap).sort((a, b) => a.risk_id.localeCompare(b.risk_id));
+
+  const taxonomies = [...new Set(riskIndex.map(r => r.taxonomy).filter(Boolean))].sort();
+
+  // Group chunks by section
+  const sectionGroups = [];
+  let currentSection = null;
+  (data.chunks || []).forEach(chunk => {
+    const title = chunk.section || 'Document';
+    if (!currentSection || currentSection.title !== title) {
+      currentSection = { title, chunks: [], riskIds: new Set() };
+      sectionGroups.push(currentSection);
+    }
+    currentSection.chunks.push(chunk);
+    (chunk.annotations || []).forEach(a => {
+      if (a.matched_in_text) currentSection.riskIds.add(a.risk_id);
+    });
+  });
+
+  return {
+    data,
+    riskIndex,
+    taxonomies,
+    groupedSections: sectionGroups,
+    sidebarFilter: '',
+    selectedTaxonomies: [],
+    hasGT: !!(data.eval),
+    gtMode: !!(data.eval),
+    gtChanges: {},
+    selectedRisk: null,
+    activeAnnotations: [],
+    occurrenceEls: [],
+    currentOccIdx: 0,
+    _currentEvIds: [],
+
+    toggleTaxFilter(tax) {
+      const idx = this.selectedTaxonomies.indexOf(tax);
+      if (idx >= 0) this.selectedTaxonomies.splice(idx, 1);
+      else this.selectedTaxonomies.push(tax);
+    },
+
+    taxFilterActive(tax) {
+      return this.selectedTaxonomies.includes(tax);
+    },
+
+    filteredRisks() {
+      let risks = this.riskIndex;
+      if (this.sidebarFilter) {
+        const q = this.sidebarFilter.toLowerCase();
+        risks = risks.filter(r =>
+          r.risk_id.toLowerCase().includes(q) ||
+          r.risk_name.toLowerCase().includes(q) ||
+          r.taxonomy.toLowerCase().includes(q)
+        );
+      }
+      if (this.selectedTaxonomies.length > 0) {
+        risks = risks.filter(r => this.selectedTaxonomies.includes(r.taxonomy));
+      }
+      return risks;
+    },
+
+    jumpToRisk(riskId) {
+      document.querySelectorAll('mark.ring-highlight').forEach(el => el.classList.remove('ring-highlight'));
+
+      this.selectedRisk = riskId;
+      this._currentEvIds = riskEvidenceIds[riskId] || [];
+      this.occurrenceEls = this._currentEvIds;
+      this.currentOccIdx = 0;
+
+      if (this._currentEvIds.length > 0) {
+        this._scrollToEvidence(0);
+      }
+    },
+
+    nextOccurrence() {
+      if (this._currentEvIds.length === 0) return;
+      this.currentOccIdx = (this.currentOccIdx + 1) % this._currentEvIds.length;
+      this._scrollToEvidence(this.currentOccIdx);
+    },
+
+    prevOccurrence() {
+      if (this._currentEvIds.length === 0) return;
+      this.currentOccIdx = (this.currentOccIdx - 1 + this._currentEvIds.length) % this._currentEvIds.length;
+      this._scrollToEvidence(this.currentOccIdx);
+    },
+
+    _scrollToEvidence(idx) {
+      document.querySelectorAll('mark.ring-highlight').forEach(el => el.classList.remove('ring-highlight'));
+
+      const evId = this._currentEvIds[idx];
+      if (!evId) return;
+
+      const marks = document.querySelectorAll('mark[data-evidence-ids~="' + evId + '"]');
+      if (marks.length === 0) return;
+
+      marks.forEach(el => el.classList.add('ring-highlight'));
+      marks[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+      // Open detail panel
+      const annsB64 = marks[0].getAttribute('data-anns');
+      if (annsB64) {
+        try {
+          const allAnns = JSON.parse(decodeURIComponent(escape(atob(annsB64))));
+          const match = allAnns.find(a => a.risk_id === this.selectedRisk);
+          if (match) this.activeAnnotations = [match];
+        } catch(e) { /* ignore */ }
+      }
+    },
+
+    renderChunk(chunk, _gtMode) {
+      const text = chunk.text || '';
+      const anns = (chunk.annotations || []).filter(a => a.matched_in_text && a.end > a.start);
+
+      // Process text with table rendering
+      const processed = this._processText(text, anns);
+      return processed;
+    },
+
+    _processText(text, anns) {
+      if (anns.length === 0) return this._renderPlainText(text);
+
+      // Interval splitting — collect boundary points
+      const points = new Set([0, text.length]);
+      anns.forEach(a => { points.add(a.start); points.add(a.end); });
+      const sorted = [...points].sort((a, b) => a - b);
+
+      // Build segments
+      const segments = [];
+      for (let i = 0; i < sorted.length - 1; i++) {
+        const segStart = sorted[i];
+        const segEnd = sorted[i + 1];
+        if (segStart === segEnd) continue;
+
+        const covering = anns.filter(a => a.start <= segStart && a.end >= segEnd);
+        segments.push({
+          start: segStart,
+          end: segEnd,
+          content: text.slice(segStart, segEnd),
+          annotations: covering,
+        });
+      }
+
+      return segments.map(seg => {
+        if (seg.annotations.length === 0) return this._renderPlainText(seg.content);
+
+        // Skip whitespace-only segments
+        if (seg.content.trim().length === 0) return this._renderPlainText(seg.content);
+
+        // Color and metadata
+        const primary = seg.annotations[0];
+        let colorClass;
+        if (this.gtMode && primary.classification) {
+          colorClass = primary.classification === 'matched' ? 'gt-matched' : 'gt-spurious';
+        } else {
+          colorClass = 'tax-' + (taxonomyColorMap[primary.taxonomy] ?? 0);
+        }
+        // Deduplicate by risk_id per segment
+        const uniqueByRisk = [];
+        const seenRids = new Set();
+        seg.annotations.forEach(a => {
+          if (!seenRids.has(a.risk_id)) { seenRids.add(a.risk_id); uniqueByRisk.push(a); }
+        });
+        const allAnnsB64 = btoa(unescape(encodeURIComponent(JSON.stringify(uniqueByRisk))));
+        const allRiskIds = uniqueByRisk.map(a => a.risk_id);
+        const allEvIds = [...new Set(seg.annotations.map(a => a.evidence_id).filter(Boolean))];
+        const riskIdAttrs = allRiskIds.map(id => this.escapeAttr(id)).join(' ');
+        const evIdAttrs = allEvIds.map(id => this.escapeAttr(id)).join(' ');
+        const titleParts = uniqueByRisk.map(a => a.risk_name + ' (' + a.risk_id + ')');
+        return `<mark class="annotation ${colorClass}" data-risk-id="${riskIdAttrs}" data-evidence-ids="${evIdAttrs}" data-anns="${allAnnsB64}" title="${this.escapeAttr(titleParts.join(' | '))}">${this.escapeHtml(seg.content)}</mark>`;
+      }).join('');
+    },
+
+    _renderPlainText(text) {
+      // Render docling table blocks as HTML tables
+      const tableRegex = /<!-- table(?:: (.+?))? -->\n?\n?([\s\S]*?)<!-- \/table -->/g;
+      let result = '';
+      let lastIdx = 0;
+
+      let match;
+      while ((match = tableRegex.exec(text)) !== null) {
+        // Pre-table text
+        if (match.index > lastIdx) {
+          result += this._escapeAndWrap(text.slice(lastIdx, match.index));
+        }
+
+        const caption = match[1] || '';
+        const tableBody = match[2];
+
+        // Parse code-fenced rows
+        const rows = [];
+        const headers = new Set();
+        const rowRegex = /```\n([\s\S]*?)\n```/g;
+        let rowMatch;
+        while ((rowMatch = rowRegex.exec(tableBody)) !== null) {
+          const rowData = {};
+          rowMatch[1].split('\n').forEach(line => {
+            const colonIdx = line.indexOf(': ');
+            if (colonIdx > 0) {
+              const key = line.slice(0, colonIdx).trim();
+              const val = line.slice(colonIdx + 2).trim();
+              rowData[key] = val;
+              headers.add(key);
+            }
+          });
+          if (Object.keys(rowData).length > 0) rows.push(rowData);
+        }
+
+        if (rows.length > 0) {
+          const headerArr = [...headers];
+          let tableHtml = '';
+          if (caption) tableHtml += `<div class="text-xs text-gray-500 mb-1 font-medium">${this.escapeHtml(caption)}</div>`;
+          tableHtml += '<table class="chunk-table"><thead><tr>';
+          headerArr.forEach(h => { tableHtml += `<th>${this.escapeHtml(h)}</th>`; });
+          tableHtml += '</tr></thead><tbody>';
+          rows.forEach(row => {
+            tableHtml += '<tr>';
+            headerArr.forEach(h => { tableHtml += `<td>${this.escapeHtml(row[h] || '')}</td>`; });
+            tableHtml += '</tr>';
+          });
+          tableHtml += '</tbody></table>';
+          result += tableHtml;
+        } else {
+          result += this._escapeAndWrap(match[0]);
+        }
+
+        lastIdx = match.index + match[0].length;
+      }
+
+      // Trailing text
+      if (lastIdx < text.length) {
+        result += this._escapeAndWrap(text.slice(lastIdx));
+      }
+
+      return result;
+    },
+
+    _escapeAndWrap(text) {
+      if (!text) return '';
+      return '<span class="whitespace-pre-wrap">' + this.escapeHtml(text) + '</span>';
+    },
+
+    handleAnnotationClick(event) {
+      const mark = event.target.closest('mark.annotation');
+      if (!mark) return;
+      const annsB64 = mark.getAttribute('data-anns');
+      if (!annsB64) return;
+      try {
+        const allAnns = JSON.parse(decodeURIComponent(escape(atob(annsB64))));
+        if (!Array.isArray(allAnns) || allAnns.length === 0) return;
+
+        if (this.selectedRisk) {
+          // Selected risk first
+          const match = allAnns.find(a => a.risk_id === this.selectedRisk);
+          if (match) {
+            const rest = allAnns.filter(a => a.risk_id !== this.selectedRisk);
+            this.activeAnnotations = [match, ...rest];
+          } else {
+            this.activeAnnotations = allAnns;
+          }
+        } else {
+          // No selection — show all
+          this.activeAnnotations = allAnns;
+        }
+      } catch(e) { /* ignore parse errors */ }
+    },
+
+    openAnnotation(ann) {
+      this.activeAnnotation = ann;
+      this.selectedRisk = ann.risk_id;
+    },
+
+    hasCausalChain(ann) {
+      if (!ann || !ann.causal_chain) return false;
+      const cc = ann.causal_chain;
+      return cc.threat || cc.threat_source || cc.vulnerability || cc.consequence || cc.impact;
+    },
+
+    causalChainFields(ann) {
+      if (!ann || !ann.causal_chain) return [];
+      const cc = ann.causal_chain;
+      const fields = [
+        { label: 'Threat', value: cc.threat },
+        { label: 'Threat Source', value: cc.threat_source },
+        { label: 'Vulnerability', value: cc.vulnerability },
+        { label: 'Consequence', value: cc.consequence },
+        { label: 'Impact', value: cc.impact },
+      ];
+      return fields.filter(f => f.value);
+    },
+
+    toggleGtChange(riskId, action) {
+      if (this.gtChanges[riskId] === action) {
+        delete this.gtChanges[riskId];
+      } else {
+        this.gtChanges[riskId] = action;
+      }
+      this.gtChanges = { ...this.gtChanges };
+    },
+
+    exportRevisedGT() {
+      const originalIds = data.gt_risk_ids || [];
+      const revised = new Set(originalIds);
+
+      for (const [riskId, action] of Object.entries(this.gtChanges)) {
+        if (action === 'add') revised.add(riskId);
+        if (action === 'remove') revised.delete(riskId);
+      }
+
+      const sortedIds = [...revised].sort();
+      let yamlStr = 'risks:\n';
+      for (const rid of sortedIds) {
+        yamlStr += '- id: ' + rid + '\n';
+      }
+
+      const blob = new Blob([yamlStr], { type: 'text/yaml' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = data.gt_filename || 'revised_gt.yaml';
+      a.click();
+      URL.revokeObjectURL(url);
+    },
+
+    escapeHtml(str) {
+      return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    },
+
+    escapeAttr(str) {
+      return str
+        .replace(/&/g, '&amp;')
+        .replace(/'/g, '&#39;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    },
+  };
+}
+</script>
+</body>
+</html>

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from asago_policy_mapper.extract.annotate import (
+    _find_span_in_chunk,
+    _locate_evidence,
+    _normalize,
+    prepare_annotation_data,
+)
+from asago_policy_mapper.extract.parse import Chunk
+
+
+class TestNormalize:
+    def test_whitespace_collapse(self):
+        assert _normalize("hello   world\n\tfoo") == "hello world foo"
+
+    def test_smart_quotes(self):
+        assert _normalize("“hello”") == '"hello"'
+        assert _normalize("‘hi’") == "'hi'"
+
+    def test_dashes(self):
+        assert _normalize("a—b–c") == "a-b-c"
+
+    def test_nbsp(self):
+        assert _normalize("a b") == "a b"
+
+    def test_nfkc(self):
+        assert _normalize("ﬁ") == "fi"
+
+
+class TestFindSpanInChunk:
+    def test_exact_match(self):
+        chunk = "The quick brown fox jumps over the lazy dog."
+        evidence = "brown fox jumps"
+        start, end, is_fuzzy = _find_span_in_chunk(evidence, chunk)
+        assert chunk[start:end] == evidence
+        assert not is_fuzzy
+
+    def test_normalized_match(self):
+        chunk = "The  quick\nbrown  fox  jumps."
+        evidence = "quick brown fox jumps."
+        start, end, is_fuzzy = _find_span_in_chunk(evidence, chunk)
+        assert start < end
+        assert not is_fuzzy
+
+    def test_smart_quote_match(self):
+        chunk = "He said “hello world” clearly."
+        evidence = 'He said "hello world" clearly.'
+        start, end, is_fuzzy = _find_span_in_chunk(evidence, chunk)
+        assert start < end
+        assert not is_fuzzy
+
+    def test_fuzzy_match(self):
+        chunk = "The quick brown fox jumps over the lazy dog near the river."
+        evidence = "The quick brown fox leaps over the lazy dog near the river."
+        start, end, is_fuzzy = _find_span_in_chunk(evidence, chunk)
+        assert start < end
+        assert is_fuzzy
+
+    def test_no_match(self):
+        chunk = "The quick brown fox."
+        evidence = "Completely unrelated text about something else entirely different."
+        start, end, is_fuzzy = _find_span_in_chunk(evidence, chunk)
+        assert start == 0
+        assert end == 0
+
+    def test_empty_evidence(self):
+        start, end, is_fuzzy = _find_span_in_chunk("", "some chunk text")
+        assert start == 0
+        assert end == 0
+
+
+class TestLocateEvidence:
+    def _make_chunks(self, texts: list[str]) -> list[Chunk]:
+        return [Chunk(text=t, source="test.txt", index=i) for i, t in enumerate(texts)]
+
+    def test_found_at_hinted_index(self):
+        chunks = self._make_chunks(["aaa bbb ccc", "ddd eee fff", "ggg hhh iii"])
+        ci, start, end, is_fuzzy = _locate_evidence("eee fff", 1, chunks)
+        assert ci == 1
+        assert chunks[ci].text[start:end] == "eee fff"
+
+    def test_wrong_hint_found_elsewhere(self):
+        chunks = self._make_chunks(["aaa bbb ccc", "ddd eee fff", "ggg hhh iii"])
+        ci, start, end, is_fuzzy = _locate_evidence("ggg hhh", 0, chunks)
+        assert ci == 2
+        assert start < end
+
+    def test_not_found_anywhere(self):
+        chunks = self._make_chunks(["aaa bbb", "ccc ddd"])
+        ci, start, end, is_fuzzy = _locate_evidence("zzz yyy xxx www", 0, chunks)
+        assert start == 0
+        assert end == 0
+
+    def test_hint_out_of_range(self):
+        chunks = self._make_chunks(["aaa bbb ccc"])
+        ci, start, end, is_fuzzy = _locate_evidence("aaa bbb", 99, chunks)
+        assert ci == 0
+        assert chunks[ci].text[start:end] == "aaa bbb"
+
+
+class TestPrepareAnnotationData:
+    @pytest.fixture()
+    def source_file(self, tmp_path: Path) -> Path:
+        text = textwrap.dedent("""\
+            Section 1: Introduction
+
+            AI systems must be transparent and accountable.
+            Organizations should ensure fairness in all AI deployments.
+
+            Section 2: Data Privacy
+
+            Personal data must be protected according to regulations.
+            Data collection should be minimized to what is necessary.
+
+            Section 3: Safety
+
+            AI systems should be tested for safety before deployment.
+            Continuous monitoring is required for production systems.
+        """)
+        p = tmp_path / "policy.txt"
+        p.write_text(text)
+        return p
+
+    @pytest.fixture()
+    def extraction_data(self) -> dict:
+        return {
+            "risks": [
+                {
+                    "risk_id": "risk-transparency",
+                    "risk_name": "Lack of Transparency",
+                    "risk_description": "AI systems not transparent",
+                    "taxonomy": "test-taxonomy",
+                    "confidence": 0.95,
+                    "grounding_confidence": "high",
+                    "evidence": [
+                        {
+                            "text": "AI systems must be transparent and accountable.",
+                            "document": "policy.txt",
+                            "chunk_index": 0,
+                        }
+                    ],
+                    "threat": "Opaque AI decisions",
+                    "threat_source": "Complex models",
+                    "vulnerability": "No explainability",
+                    "consequence": "Loss of trust",
+                    "impact": "Regulatory action",
+                },
+                {
+                    "risk_id": "risk-privacy",
+                    "risk_name": "Privacy Violation",
+                    "risk_description": "Data privacy not ensured",
+                    "taxonomy": "test-taxonomy",
+                    "confidence": 0.88,
+                    "grounding_confidence": "medium",
+                    "evidence": [
+                        {
+                            "text": "Personal data must be protected according to regulations.",
+                            "document": "policy.txt",
+                            "chunk_index": 0,
+                        }
+                    ],
+                    "threat": None,
+                    "threat_source": None,
+                    "vulnerability": None,
+                    "consequence": None,
+                    "impact": None,
+                },
+            ],
+            "metadata": {"model": "test-model", "policy": "test-policy"},
+        }
+
+    def test_basic_output_structure(self, source_file: Path, extraction_data: dict):
+        result = prepare_annotation_data(extraction_data, source_file)
+
+        assert "chunks" in result
+        assert "summary" in result
+        assert "metadata" in result
+        assert len(result["chunks"]) > 0
+
+    def test_summary_counts(self, source_file: Path, extraction_data: dict):
+        result = prepare_annotation_data(extraction_data, source_file)
+        summary = result["summary"]
+
+        assert summary["total_risks"] == 2
+        assert summary["total_evidence_spans"] == 2
+        assert summary["matched_spans"] + summary["unmatched_spans"] == 2
+
+    def test_annotations_have_required_fields(self, source_file: Path, extraction_data: dict):
+        result = prepare_annotation_data(extraction_data, source_file)
+
+        for chunk in result["chunks"]:
+            for ann in chunk["annotations"]:
+                assert "start" in ann
+                assert "end" in ann
+                assert "evidence_text" in ann
+                assert "matched_in_text" in ann
+                assert "risk_id" in ann
+                assert "risk_name" in ann
+                assert "taxonomy" in ann
+                assert "confidence" in ann
+                assert "causal_chain" in ann
+
+    def test_causal_chain_populated(self, source_file: Path, extraction_data: dict):
+        result = prepare_annotation_data(extraction_data, source_file)
+
+        all_annotations = [a for c in result["chunks"] for a in c["annotations"]]
+        transparency = [a for a in all_annotations if a["risk_id"] == "risk-transparency"]
+        assert len(transparency) == 1
+        cc = transparency[0]["causal_chain"]
+        assert cc["threat"] == "Opaque AI decisions"
+        assert cc["impact"] == "Regulatory action"
+
+    def test_causal_chain_none_fields(self, source_file: Path, extraction_data: dict):
+        result = prepare_annotation_data(extraction_data, source_file)
+
+        all_annotations = [a for c in result["chunks"] for a in c["annotations"]]
+        privacy = [a for a in all_annotations if a["risk_id"] == "risk-privacy"]
+        assert len(privacy) == 1
+        cc = privacy[0]["causal_chain"]
+        assert cc["threat"] is None
+        assert cc["impact"] is None
+
+    def test_metadata_passed_through(self, source_file: Path, extraction_data: dict):
+        result = prepare_annotation_data(extraction_data, source_file)
+        assert result["metadata"]["model"] == "test-model"
+
+    def test_zero_risks(self, source_file: Path):
+        result = prepare_annotation_data({"risks": [], "metadata": {}}, source_file)
+        assert result["summary"]["total_risks"] == 0
+        assert result["summary"]["total_evidence_spans"] == 0
+        assert all(len(c["annotations"]) == 0 for c in result["chunks"])
+
+    def test_chunk_fields(self, source_file: Path, extraction_data: dict):
+        result = prepare_annotation_data(extraction_data, source_file)
+        for chunk in result["chunks"]:
+            assert "index" in chunk
+            assert "text" in chunk
+            assert "page" in chunk
+            assert "section" in chunk
+            assert "annotations" in chunk
+            assert isinstance(chunk["text"], str)
+            assert len(chunk["text"]) > 0
+
+    def test_annotations_sorted_by_start(self, source_file: Path):
+        extraction_data = {
+            "risks": [
+                {
+                    "risk_id": f"risk-{i}",
+                    "risk_name": f"Risk {i}",
+                    "risk_description": "",
+                    "taxonomy": "",
+                    "confidence": 0.9,
+                    "grounding_confidence": "high",
+                    "evidence": [{"text": text, "document": "policy.txt", "chunk_index": 0}],
+                }
+                for i, text in enumerate(
+                    [
+                        "Organizations should ensure fairness",
+                        "AI systems must be transparent",
+                    ]
+                )
+            ],
+            "metadata": {},
+        }
+
+        result = prepare_annotation_data(extraction_data, source_file)
+        for chunk in result["chunks"]:
+            if len(chunk["annotations"]) > 1:
+                starts = [a["start"] for a in chunk["annotations"]]
+                assert starts == sorted(starts)
+
+    def test_overlapping_spans(self, source_file: Path):
+        extraction_data = {
+            "risks": [
+                {
+                    "risk_id": "risk-a",
+                    "risk_name": "Risk A",
+                    "risk_description": "",
+                    "taxonomy": "",
+                    "confidence": 0.9,
+                    "grounding_confidence": "high",
+                    "evidence": [
+                        {
+                            "text": "AI systems must be transparent and accountable.",
+                            "document": "policy.txt",
+                            "chunk_index": 0,
+                        }
+                    ],
+                },
+                {
+                    "risk_id": "risk-b",
+                    "risk_name": "Risk B",
+                    "risk_description": "",
+                    "taxonomy": "",
+                    "confidence": 0.85,
+                    "grounding_confidence": "medium",
+                    "evidence": [
+                        {
+                            "text": "transparent and accountable.",
+                            "document": "policy.txt",
+                            "chunk_index": 0,
+                        }
+                    ],
+                },
+            ],
+            "metadata": {},
+        }
+
+        result = prepare_annotation_data(extraction_data, source_file)
+        all_annotations = [a for c in result["chunks"] for a in c["annotations"]]
+        matched = [a for a in all_annotations if a["matched_in_text"]]
+        assert len(matched) == 2
+
+    def test_unmatched_span(self, source_file: Path):
+        extraction_data = {
+            "risks": [
+                {
+                    "risk_id": "risk-missing",
+                    "risk_name": "Missing",
+                    "risk_description": "",
+                    "taxonomy": "",
+                    "confidence": 0.5,
+                    "grounding_confidence": "low",
+                    "evidence": [
+                        {
+                            "text": "This text does not exist anywhere in the document at all whatsoever.",
+                            "document": "policy.txt",
+                            "chunk_index": 0,
+                        }
+                    ],
+                }
+            ],
+            "metadata": {},
+        }
+
+        result = prepare_annotation_data(extraction_data, source_file)
+        assert result["summary"]["unmatched_spans"] == 1
+        all_annotations = [a for c in result["chunks"] for a in c["annotations"]]
+        assert len(all_annotations) == 1
+        assert not all_annotations[0]["matched_in_text"]


### PR DESCRIPTION
## Summary

Adds a document-centric annotation view that renders the source policy document with extracted risks highlighted inline at their evidence locations. Produced automatically alongside `risk-extraction.html` during every extraction run, or standalone via the new `annotate` CLI command.

- **Data preparation** (`annotate.py`) — re-parses the source document, locates each evidence quote within chunk text using 4-tier matching (exact → normalized → scan all chunks → fuzzy), deduplicates overlapping spans from multi-pass grounding
- **HTML template** — self-contained Alpine.js + Tailwind report with sidebar risk index, taxonomy filtering, occurrence navigation (prev/next), interval splitting for overlapping annotations, click-to-inspect detail panel showing all risks on a span
- **CLI wiring** — new `annotate` command with `--ground-truth` flag, auto-generation hooked into the `extract` command
- **Ground truth overlay** — toggle between extraction view and GT comparison view (TP/FP/FN classification), interactive GT curation with export of revised YAML

### Usage

```bash
# Auto-generated during extraction
asago-policy-mapper extract policy.pdf -o output/ --base-url ... --model ...
# output/risk-annotation.html is created alongside risk-extraction.html

# Standalone generation
asago-policy-mapper annotate output/ policy.pdf

# With ground truth comparison
asago-policy-mapper annotate output/ policy.pdf --ground-truth evals/ground_truth/policy.yaml
```

### Smoke test (Penn policy)
- 108 risks, 236 evidence spans, 215 matched (91%)
- GT comparison: P=0.509 R=0.917 F1=0.655

## Test plan

- [x] 26 unit tests covering normalization, exact/fuzzy/overlap matching, zero-risk case, output structure
- [x] All existing tests pass (34 total)
- [x] Lint, format, mypy clean
- [x] Smoke tested with Penn policy extraction run
- [x] Verified in browser: sidebar navigation, occurrence cycling, detail panel, GT toggle, export