### PR TITLE
feat: custom taxonomy loader and validator (RHOAIENG-79784)

### DIFF
--- a/examples/custom-taxonomy-example.yaml
+++ b/examples/custom-taxonomy-example.yaml
@@ -1,0 +1,73 @@
+# Custom Taxonomy Example - Red Hat AI Controls
+#
+# This file demonstrates the custom taxonomy format for asago-policy-mapper.
+# Use --custom-taxonomy to load it alongside built-in Nexus risks during extraction.
+#
+# Usage:
+#   asago-policy-mapper extract policy.pdf -o output/ \
+#       --custom-taxonomy examples/custom-taxonomy-example.yaml \
+#       --base-url http://localhost:8000/v1 --model gemma4-26b-a4b-it
+
+# Required: taxonomy metadata
+taxonomy:
+  id: red-hat-ai-controls           # unique identifier, appears in extraction results
+  name: Red Hat AI Controls          # human-readable name
+  description: >-                    # optional
+    Internal AI controls framework for Red Hat AI Safety,
+    covering model lifecycle governance and operational requirements.
+
+# Required: at least one risk
+risks:
+  - id: rh-ctrl-001
+    name: Model Card Completeness
+    description: >-
+      AI models deployed in production must have a complete model card
+      documenting training data, intended use, limitations, and evaluation
+      results. Model cards should follow the standard template and be
+      reviewed before deployment approval.
+    concern: >-
+      Incomplete model documentation prevents downstream users from
+      assessing model suitability for their use case and creates
+      compliance gaps during audits.
+
+  - id: rh-ctrl-002
+    name: Inference Endpoint Authentication
+    description: >-
+      All AI model inference endpoints must require authentication and
+      authorization before serving predictions. Endpoints exposed without
+      access controls risk unauthorized usage, data leakage, and abuse
+      of compute resources.
+
+  - id: rh-ctrl-003
+    name: Training Data Provenance
+    description: >-
+      Training datasets must have documented provenance including source,
+      collection methodology, licensing terms, and any preprocessing
+      applied. Data lineage must be traceable from raw source to the
+      final training split.
+    concern: >-
+      Without provenance tracking, organizations cannot verify compliance
+      with data usage agreements or identify potential bias sources
+      introduced during collection or preprocessing.
+    risk_type: governance            # optional: "technical", "governance", "non-technical"
+
+  - id: rh-ctrl-004
+    name: Model Performance Drift Monitoring
+    description: >-
+      Deployed AI models must be continuously monitored for performance
+      drift. Automated alerts should trigger when key metrics degrade
+      beyond defined thresholds, prompting retraining or rollback
+      decisions.
+    concern: >-
+      Undetected performance drift can lead to silently degraded
+      predictions affecting downstream business decisions.
+    risk_type: technical
+
+  - id: rh-ctrl-005
+    name: Adversarial Robustness Testing
+    description: >-
+      AI models handling sensitive or safety-critical tasks must undergo
+      adversarial robustness testing before production deployment.
+      Testing should cover known attack vectors relevant to the model
+      type and deployment context.
+    risk_type: technical

--- a/src/asago_policy_mapper/taxonomy.py
+++ b/src/asago_policy_mapper/taxonomy.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+from ai_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import Risk
+
+logger = logging.getLogger(__name__)
+
+_BUILTIN_PREFIXES = ("atlas-", "nist-", "credo-", "mit-", "owasp-", "asi-")
+
+
+def load_custom_taxonomy(path: Path) -> list[Risk]:
+    """Load and validate a custom taxonomy YAML file.
+
+    Returns a list of Risk objects ready to be passed to run_extraction().
+    Raises ValueError with actionable messages on validation failure.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise ValueError(f"Custom taxonomy file not found: {path}")
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML in {path}: {e}") from e
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Custom taxonomy file must be a YAML mapping, got {type(raw).__name__} in {path}")
+
+    _validate_taxonomy_block(raw, path)
+    taxonomy_id = raw["taxonomy"]["id"]
+    taxonomy_name = raw["taxonomy"]["name"]
+
+    if "risks" not in raw:
+        raise ValueError(f"Custom taxonomy {path} is missing the 'risks' key")
+    if not isinstance(raw["risks"], list) or len(raw["risks"]) == 0:
+        raise ValueError(f"Custom taxonomy {path} has an empty or invalid 'risks' list - at least one risk is required")
+
+    risks: list[Risk] = []
+    seen_ids: set[str] = set()
+
+    for i, entry in enumerate(raw["risks"]):
+        _validate_risk_entry(entry, i, path)
+
+        rid = entry["id"]
+        if rid in seen_ids:
+            raise ValueError(f"Duplicate risk ID '{rid}' in {path}")
+        seen_ids.add(rid)
+
+        for prefix in _BUILTIN_PREFIXES:
+            if rid.startswith(prefix):
+                logger.warning(
+                    "Risk '%s' in %s uses built-in prefix '%s' - this may collide with Nexus risks",
+                    rid,
+                    path,
+                    prefix,
+                )
+                break
+
+        desc = entry["description"]
+        if len(desc.strip()) < 10:
+            logger.warning(
+                "Risk '%s' in %s has a very short description (%d chars) - retrieval quality may be poor",
+                rid,
+                path,
+                len(desc.strip()),
+            )
+
+        risks.append(
+            Risk(
+                id=rid,
+                name=entry["name"],
+                description=desc,
+                isDefinedByTaxonomy=taxonomy_id,
+                concern=entry.get("concern", ""),
+                risk_type=entry.get("risk_type"),
+                type="Risk",
+            )
+        )
+
+    logger.info(
+        "Loaded %d custom risks from taxonomy '%s' (%s)",
+        len(risks),
+        taxonomy_name,
+        path,
+    )
+    return risks
+
+
+def _validate_taxonomy_block(raw: dict, path: Path) -> None:
+    if "taxonomy" not in raw:
+        raise ValueError(f"Custom taxonomy {path} is missing the 'taxonomy' block")
+
+    tax = raw["taxonomy"]
+    if not isinstance(tax, dict):
+        raise ValueError(f"'taxonomy' in {path} must be a mapping, got {type(tax).__name__}")
+
+    for field in ("id", "name"):
+        if field not in tax or not isinstance(tax[field], str) or not tax[field].strip():
+            raise ValueError(f"'taxonomy.{field}' is missing or empty in {path}")
+
+
+def _validate_risk_entry(entry: dict, index: int, path: Path) -> None:
+    if not isinstance(entry, dict):
+        raise ValueError(f"Risk at index {index} in {path} must be a mapping, got {type(entry).__name__}")
+
+    for field in ("id", "name", "description"):
+        if field not in entry:
+            raise ValueError(f"Risk at index {index} in {path} is missing required field '{field}'")
+        val = entry[field]
+        if not isinstance(val, str) or not val.strip():
+            raise ValueError(
+                f"Risk '{entry.get('id', f'index {index}')}' in {path} has an empty or non-string '{field}'"
+            )

--- a/src/asago_policy_mapper/taxonomy.py
+++ b/src/asago_policy_mapper/taxonomy.py
@@ -6,9 +6,11 @@ from pathlib import Path
 import yaml
 from ai_atlas_nexus.ai_risk_ontology.datamodel.ai_risk_ontology import Risk
 
+from asago_policy_mapper.evals.eval import _TAXONOMY_PREFIXES
+
 logger = logging.getLogger(__name__)
 
-_BUILTIN_PREFIXES = ("atlas-", "nist-", "credo-", "mit-", "owasp-", "asi-")
+_BUILTIN_PREFIXES = tuple(prefix for prefix, _ in _TAXONOMY_PREFIXES)
 
 
 def load_custom_taxonomy(path: Path) -> list[Risk]:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,209 @@
+from pathlib import Path
+
+import pytest
+
+from asago_policy_mapper.taxonomy import load_custom_taxonomy
+
+
+@pytest.fixture
+def valid_taxonomy(tmp_path):
+    f = tmp_path / "valid.yaml"
+    f.write_text(
+        """\
+taxonomy:
+  id: test-taxonomy
+  name: Test Taxonomy
+
+risks:
+  - id: test-001
+    name: First Risk
+    description: >-
+      A sufficiently detailed description of the first risk
+      for retrieval quality.
+    concern: Why this risk matters.
+  - id: test-002
+    name: Second Risk
+    description: >-
+      A sufficiently detailed description of the second risk
+      for retrieval quality.
+  - id: test-003
+    name: Third Risk
+    description: >-
+      A sufficiently detailed description of the third risk
+      for retrieval quality.
+    risk_type: technical
+"""
+    )
+    return f
+
+
+def test_valid_load(valid_taxonomy):
+    risks = load_custom_taxonomy(valid_taxonomy)
+    assert len(risks) == 3
+    assert risks[0].id == "test-001"
+    assert risks[0].name == "First Risk"
+    assert risks[0].isDefinedByTaxonomy == "test-taxonomy"
+    assert risks[0].concern == "Why this risk matters."
+    assert risks[0].type == "Risk"
+
+
+def test_taxonomy_attribution(valid_taxonomy):
+    risks = load_custom_taxonomy(valid_taxonomy)
+    for r in risks:
+        assert r.isDefinedByTaxonomy == "test-taxonomy"
+
+
+def test_concern_defaults_empty(valid_taxonomy):
+    risks = load_custom_taxonomy(valid_taxonomy)
+    assert risks[1].concern == ""
+
+
+def test_concern_populated(valid_taxonomy):
+    risks = load_custom_taxonomy(valid_taxonomy)
+    assert risks[0].concern == "Why this risk matters."
+
+
+def test_risk_type_populated(valid_taxonomy):
+    risks = load_custom_taxonomy(valid_taxonomy)
+    assert risks[2].risk_type == "technical"
+
+
+def test_risk_type_defaults_none(valid_taxonomy):
+    risks = load_custom_taxonomy(valid_taxonomy)
+    assert risks[0].risk_type is None
+
+
+def test_missing_taxonomy_block(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text("risks:\n  - id: x\n    name: X\n    description: some description here\n")
+    with pytest.raises(ValueError, match="missing the 'taxonomy' block"):
+        load_custom_taxonomy(f)
+
+
+def test_missing_taxonomy_id(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text("taxonomy:\n  name: Test\nrisks:\n  - id: x\n    name: X\n    description: some description here\n")
+    with pytest.raises(ValueError, match="taxonomy.id"):
+        load_custom_taxonomy(f)
+
+
+def test_missing_taxonomy_name(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text("taxonomy:\n  id: test\nrisks:\n  - id: x\n    name: X\n    description: some description here\n")
+    with pytest.raises(ValueError, match="taxonomy.name"):
+        load_custom_taxonomy(f)
+
+
+def test_missing_risks_key(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text("taxonomy:\n  id: test\n  name: Test\n")
+    with pytest.raises(ValueError, match="missing the 'risks' key"):
+        load_custom_taxonomy(f)
+
+
+def test_empty_risks_list(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text("taxonomy:\n  id: test\n  name: Test\nrisks: []\n")
+    with pytest.raises(ValueError, match="empty or invalid 'risks' list"):
+        load_custom_taxonomy(f)
+
+
+def test_missing_risk_description(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text("taxonomy:\n  id: test\n  name: Test\nrisks:\n  - id: x\n    name: X\n")
+    with pytest.raises(ValueError, match="missing required field 'description'"):
+        load_custom_taxonomy(f)
+
+
+def test_missing_risk_name(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text("taxonomy:\n  id: test\n  name: Test\nrisks:\n  - id: x\n    description: some description here\n")
+    with pytest.raises(ValueError, match="missing required field 'name'"):
+        load_custom_taxonomy(f)
+
+
+def test_missing_risk_id(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text("taxonomy:\n  id: test\n  name: Test\nrisks:\n  - name: X\n    description: some description here\n")
+    with pytest.raises(ValueError, match="missing required field 'id'"):
+        load_custom_taxonomy(f)
+
+
+def test_empty_description(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text("taxonomy:\n  id: test\n  name: Test\nrisks:\n  - id: x\n    name: X\n    description: ''\n")
+    with pytest.raises(ValueError, match="empty or non-string"):
+        load_custom_taxonomy(f)
+
+
+def test_duplicate_risk_ids(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text(
+        """\
+taxonomy:
+  id: test
+  name: Test
+risks:
+  - id: dupe-001
+    name: First
+    description: A sufficiently long description for the first risk
+  - id: dupe-001
+    name: Second
+    description: A sufficiently long description for the second risk
+"""
+    )
+    with pytest.raises(ValueError, match="Duplicate risk ID 'dupe-001'"):
+        load_custom_taxonomy(f)
+
+
+def test_short_description_warns(tmp_path, caplog):
+    f = tmp_path / "short.yaml"
+    f.write_text("taxonomy:\n  id: test\n  name: Test\nrisks:\n  - id: x\n    name: X\n    description: Short\n")
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        risks = load_custom_taxonomy(f)
+    assert len(risks) == 1
+    assert "very short description" in caplog.text
+
+
+def test_builtin_prefix_warns(tmp_path, caplog):
+    f = tmp_path / "prefix.yaml"
+    f.write_text(
+        """\
+taxonomy:
+  id: test
+  name: Test
+risks:
+  - id: atlas-custom-risk
+    name: Custom Risk
+    description: A sufficiently long description that uses a built-in prefix
+"""
+    )
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        risks = load_custom_taxonomy(f)
+    assert len(risks) == 1
+    assert "built-in prefix" in caplog.text
+
+
+def test_file_not_found():
+    with pytest.raises(ValueError, match="not found"):
+        load_custom_taxonomy(Path("/nonexistent/taxonomy.yaml"))
+
+
+def test_invalid_yaml(tmp_path):
+    f = tmp_path / "bad.yaml"
+    f.write_text(":\n  - ][invalid yaml")
+    with pytest.raises(ValueError, match="Invalid YAML"):
+        load_custom_taxonomy(f)
+
+
+def test_example_file_loads():
+    example = Path(__file__).parent.parent / "examples" / "custom-taxonomy-example.yaml"
+    if not example.exists():
+        pytest.skip("Example file not found")
+    risks = load_custom_taxonomy(example)
+    assert len(risks) == 5
+    assert all(r.isDefinedByTaxonomy == "red-hat-ai-controls" for r in risks)


### PR DESCRIPTION
## Summary

- Add `taxonomy.py` module with `load_custom_taxonomy()` that reads a user-provided YAML file, validates it, and returns `Risk` objects compatible with the extraction pipeline
- Validation covers: taxonomy block with ID/name, required fields per risk (id, name, description), duplicate IDs, empty risk lists, short descriptions, and built-in prefix collisions
- Fails fast with actionable error messages; warns but doesn't block on quality issues (short descriptions, prefix collisions)
- Add example taxonomy file (`examples/custom-taxonomy-example.yaml`) with 5 realistic Red Hat AI Controls risks
- 21 unit tests covering valid loads, all validation error paths, and warning cases

## JIRA

RHOAIENG-79784

## Test plan

- [x] 21 unit tests pass (`uv run pytest tests/test_taxonomy.py -v`)
- [x] Full test suite passes with no regressions (346 passed)
- [x] Lint, format, and type checks pass
- [x] Example taxonomy file loads correctly (verified by `test_example_file_loads`)

## Next

This is PR 1 of 4 for custom taxonomy support:
1. **Loader and validator** (this PR)
2. CLI `--custom-taxonomy` flag (RHOAIENG-79785) - depends on this PR
3. Documentation (RHOAIENG-79790)
4. Eval per-taxonomy breakdown (RHOAIENG-79791)