### PR TITLE
feat: --custom-taxonomy CLI flag (RHOAIENG-79785)

### DIFF
--- a/src/asago_policy_mapper/cli.py
+++ b/src/asago_policy_mapper/cli.py
@@ -36,6 +36,9 @@ def extract(
     nexus_base_dir: str = typer.Option(
         None, "--nexus-base-dir", envvar="NEXUS_BASE_DIR", help="Path to ai-atlas-nexus repo"
     ),
+    custom_taxonomy: list[Path] = typer.Option(
+        [], "--custom-taxonomy", "-t", help="Custom taxonomy YAML file(s) to load alongside Nexus risks"
+    ),
     debug_dir: Path = typer.Option(None, "--debug", help="Directory for per-call debug logs"),
     max_concurrent: int = typer.Option(32, "--max-concurrent", help="Max parallel LLM calls"),
     ocr: bool = typer.Option(False, "--ocr", help="Enable OCR for document conversion"),
@@ -184,6 +187,21 @@ def extract(
     nexus = AIAtlasNexus(base_dir=nexus_base_dir)
     all_risks = [r for r in nexus.get_all_risks() if getattr(r, "isDefinedByTaxonomy", "") not in EXCLUDED_TAXONOMIES]
 
+    custom_risk_count = 0
+    if custom_taxonomy:
+        from asago_policy_mapper.taxonomy import load_custom_taxonomy
+
+        nexus_ids = {r.id for r in all_risks}
+        for tax_path in custom_taxonomy:
+            custom_risks = load_custom_taxonomy(tax_path)
+            for cr in custom_risks:
+                if cr.id in nexus_ids:
+                    typer.echo(f"Warning: custom risk '{cr.id}' collides with a built-in risk - skipping", err=True)
+                else:
+                    all_risks.append(cr)
+                    custom_risk_count += 1
+            typer.echo(f"Loaded {len(custom_risks)} custom risks from {tax_path}")
+
     from asago_policy_mapper.extract.models import RetrievalConfig
     from asago_policy_mapper.extract.pipeline import run_extraction
 
@@ -215,7 +233,13 @@ def extract(
         query_gen=query_gen,
     )
 
-    typer.echo(f"Extracting risks from {len(policy_files)} document(s) ({len(all_risks)} Nexus risks loaded)...")
+    if custom_risk_count:
+        typer.echo(
+            f"Extracting risks from {len(policy_files)} document(s) "
+            f"({len(all_risks) - custom_risk_count} Nexus + {custom_risk_count} custom risks loaded)..."
+        )
+    else:
+        typer.echo(f"Extracting risks from {len(policy_files)} document(s) ({len(all_risks)} Nexus risks loaded)...")
 
     result = run_extraction(
         documents=policy_files,

--- a/src/asago_policy_mapper/cli.py
+++ b/src/asago_policy_mapper/cli.py
@@ -182,25 +182,34 @@ def extract(
 
     output.mkdir(parents=True, exist_ok=True)
 
+    loaded_custom_risks: list = []
+    if custom_taxonomy:
+        from asago_policy_mapper.taxonomy import load_custom_taxonomy
+
+        for tax_path in custom_taxonomy:
+            try:
+                custom_risks = load_custom_taxonomy(tax_path)
+            except ValueError as e:
+                typer.echo(f"Error: {e}", err=True)
+                raise typer.Exit(1) from e
+            loaded_custom_risks.extend(custom_risks)
+            typer.echo(f"Loaded {len(custom_risks)} custom risks from {tax_path}")
+
     from ai_atlas_nexus import AIAtlasNexus
 
     nexus = AIAtlasNexus(base_dir=nexus_base_dir)
     all_risks = [r for r in nexus.get_all_risks() if getattr(r, "isDefinedByTaxonomy", "") not in EXCLUDED_TAXONOMIES]
 
     custom_risk_count = 0
-    if custom_taxonomy:
-        from asago_policy_mapper.taxonomy import load_custom_taxonomy
-
-        nexus_ids = {r.id for r in all_risks}
-        for tax_path in custom_taxonomy:
-            custom_risks = load_custom_taxonomy(tax_path)
-            for cr in custom_risks:
-                if cr.id in nexus_ids:
-                    typer.echo(f"Warning: custom risk '{cr.id}' collides with a built-in risk - skipping", err=True)
-                else:
-                    all_risks.append(cr)
-                    custom_risk_count += 1
-            typer.echo(f"Loaded {len(custom_risks)} custom risks from {tax_path}")
+    if loaded_custom_risks:
+        seen_ids = {r.id for r in all_risks}
+        for cr in loaded_custom_risks:
+            if cr.id in seen_ids:
+                typer.echo(f"Warning: custom risk '{cr.id}' collides with an existing risk - skipping", err=True)
+            else:
+                all_risks.append(cr)
+                seen_ids.add(cr.id)
+                custom_risk_count += 1
 
     from asago_policy_mapper.extract.models import RetrievalConfig
     from asago_policy_mapper.extract.pipeline import run_extraction

--- a/tests/test_extract_cli.py
+++ b/tests/test_extract_cli.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 
 from typer.testing import CliRunner
@@ -5,6 +6,10 @@ from typer.testing import CliRunner
 from asago_policy_mapper.cli import app
 
 runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
 def test_extract_command_exists():
@@ -54,7 +59,7 @@ def test_extract_nonexistent_file():
 def test_extract_custom_taxonomy_flag_in_help():
     result = runner.invoke(app, ["extract", "--help"])
     assert result.exit_code == 0
-    assert "--custom-taxonomy" in result.stdout
+    assert "--custom-taxonomy" in _strip_ansi(result.stdout)
 
 
 def test_extract_invalid_custom_taxonomy():

--- a/tests/test_extract_cli.py
+++ b/tests/test_extract_cli.py
@@ -92,6 +92,8 @@ def test_extract_invalid_custom_taxonomy():
                 env={"POLICY_MAPPER_BASE_URL": "", "POLICY_MAPPER_MODEL": ""},
             )
     assert result.exit_code != 0
+    output = _strip_ansi(result.stdout + (result.stderr or ""))
+    assert "missing the 'taxonomy' block" in output
 
 
 def test_eval_command_exists():

--- a/tests/test_extract_cli.py
+++ b/tests/test_extract_cli.py
@@ -51,6 +51,44 @@ def test_extract_nonexistent_file():
     assert result.exit_code != 0
 
 
+def test_extract_custom_taxonomy_flag_in_help():
+    result = runner.invoke(app, ["extract", "--help"])
+    assert result.exit_code == 0
+    assert "--custom-taxonomy" in result.stdout
+
+
+def test_extract_invalid_custom_taxonomy():
+    with tempfile.NamedTemporaryFile(suffix=".txt", mode="w", delete=False) as f:
+        f.write("test policy")
+        f.flush()
+        with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as bad_yaml:
+            bad_yaml.write("not_a_taxonomy: true\n")
+            bad_yaml.flush()
+            result = runner.invoke(
+                app,
+                [
+                    "extract",
+                    f.name,
+                    "-o",
+                    "/tmp/test-output",
+                    "--base-url",
+                    "http://localhost:8000/v1",
+                    "--model",
+                    "test",
+                    "--nexus-base-dir",
+                    "/tmp/nexus",
+                    "--custom-taxonomy",
+                    bad_yaml.name,
+                    "--no-judge",
+                    "--no-grounding",
+                    "--no-expand-siblings",
+                    "--no-query-gen",
+                ],
+                env={"POLICY_MAPPER_BASE_URL": "", "POLICY_MAPPER_MODEL": ""},
+            )
+    assert result.exit_code != 0
+
+
 def test_eval_command_exists():
     result = runner.invoke(app, ["eval", "--help"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary

- Add repeatable `--custom-taxonomy` / `-t` flag to the `extract` command
- Loads custom taxonomy YAML files via the loader from PR #60, validates, and appends custom risks to the built-in Nexus risk list
- Warns and skips custom risks whose IDs collide with built-in Nexus risks
- Updates the status echo to show Nexus + custom risk counts separately
- Backwards compatible, behavior unchanged without the flag

## Files changed

- `src/asago_policy_mapper/cli.py` - new `custom_taxonomy` parameter, loading/collision logic, updated echo message
- `tests/test_extract_cli.py` - 2 new tests: flag appears in `--help`, invalid YAML triggers error

## JIRA

RHOAIENG-79785

## Test plan

- [x] `--custom-taxonomy` flag appears in `extract --help`
- [x] Invalid custom taxonomy YAML: extraction fails with clear error
- [x] Full test suite passes (348 passed, 0 failures)
- [x] Lint, format, and type checks pass

## Depends on

- PR #60 (custom-taxonomy-loader) - must merge first

## Next

PR 3: Documentation (RHOAIENG-79790)
PR 4: Eval per-taxonomy breakdown (RHOAIENG-79791)