### PR TITLE
Fix risk extraction hangs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ uv run pytest --test-llm -m llm -v -s --tb=short -W ignore::DeprecationWarning
 
 The pipeline in `src/asago_policy_mapper/extract/pipeline.py` has several alternative modes controlled by CLI flags — when modifying one path, be aware the others exist:
 
-- **Default (query-gen on):** LLM generates search queries per section group, all candidates go to grounding. Disable with `--no-query-gen` to use per-chunk BM25+semantic retrieval with cross-encoder reranking and LLM judging.
+- **Default (query-gen on):** LLM generates search queries per section group, candidates (capped at 50 per chunk by RRF after query union) go to grounding in batches of `--grounding-batch-size` (default 15). Disable with `--no-query-gen` to use per-chunk BM25+semantic retrieval with cross-encoder reranking and LLM judging.
 - `--no-cross-encoder`: RRF score floor filtering replaces cross-encoder reranking (no LLM judging)
 - `--no-judge`: borderline candidates auto-promoted (skips LLM judge)
 - `--no-grounding`: accepted candidates become matches without evidence extraction
@@ -59,7 +59,7 @@ The pipeline in `src/asago_policy_mapper/extract/pipeline.py` has several altern
 
 **Variant collapsing:** Risk IDs containing `---` (e.g. `unauthorized-processing---biometric-data`) are collapsed into synthetic parent entries for indexing. After grounding, a variant grounding step determines which specific sub-types have evidence. This affects how risk IDs flow through the entire pipeline — don't treat `---` IDs as regular risks.
 
-**Multi-pass grounding:** Grounding and expansion each run multiple passes (default 3) and union results to reduce LLM non-determinism. Do not remove the extra passes — they stabilize which risks survive grounding.
+**Multi-pass grounding:** Grounding and expansion each run multiple passes (default 3) and union results to reduce LLM non-determinism. Do not remove the extra passes — they stabilize which risks survive grounding. Grounding JSON is split into batches (`grounding_batch_size`, default 15) so responses stay within `LLMConfig.max_tokens` (always sent to the API, default 8192).
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ LLM prompts are Jinja2 templates in `src/asago_policy_mapper/templates/prompts/`
 All LLM calls go through `llm.py`, which wraps the OpenAI client with [instructor](https://github.com/instructor-ai/instructor) for structured Pydantic outputs. `TokenTracker` accumulates token usage across pipeline stages; `LLMConfig` holds connection details.
 
 - Automatic retry on validation errors (appends error hint), context overflow detection (reduces `max_tokens`), and prompt truncation on incomplete output
+- `LLMConfig.max_tokens` (default 8192) is always sent on chat completions. Without this, vLLM treats omitted `max_tokens` as “fill the remaining context”, so grounding calls can generate for tens of minutes. Override with `--max-tokens` / `--max-context`.
+- Grounding splits candidate lists into `--grounding-batch-size` risks per call (default 15) so structured JSON fits in the output budget.
 - Sampling parameters (`temperature`, `top_p`, `top_k`) are injected by the tracking wrapper from `LLMConfig` defaults — call sites don't set them directly. `top_k` is passed via `extra_body` for vLLM compatibility.
 - All LLM calls default to `temperature=0.0`; override with `--temperature`, `--top-p`, `--top-k` CLI flags (e.g. `--temperature 1.0 --top-p 0.95 --top-k 64` for Gemma 4)
 

--- a/src/asago_policy_mapper/cli.py
+++ b/src/asago_policy_mapper/cli.py
@@ -41,6 +41,10 @@ def extract(
     ),
     debug_dir: Path = typer.Option(None, "--debug", help="Directory for per-call debug logs"),
     max_concurrent: int = typer.Option(32, "--max-concurrent", help="Max parallel LLM calls"),
+    max_tokens: int = typer.Option(8192, "--max-tokens", help="Max LLM output tokens per call (default: 8192)"),
+    max_context: int = typer.Option(
+        0, "--max-context", help="Model context window in tokens (0=do not budget against context)"
+    ),
     ocr: bool = typer.Option(False, "--ocr", help="Enable OCR for document conversion"),
     chunk_max_tokens: int = typer.Option(512, "--chunk-max-tokens", help="Max tokens per chunk (default: 512)"),
     top_n_accept: int = typer.Option(10, "--top-n-accept", help="Auto-accept top N candidates per chunk (rank-based)"),
@@ -106,6 +110,11 @@ def extract(
         "--grounding-passes",
         help="Number of per-chunk grounding passes; union of results reduces variance (default: 3)",
     ),
+    grounding_batch_size: int = typer.Option(
+        15,
+        "--grounding-batch-size",
+        help="Max candidate risks per grounding LLM call (default: 15; 0=no split)",
+    ),
     expansion_passes: int = typer.Option(
         3,
         "--expansion-passes",
@@ -160,6 +169,8 @@ def extract(
             model=model or "unused",
             api_key=api_key,
             max_concurrent=max_concurrent,
+            max_tokens=max_tokens,
+            max_context=max_context,
             temperature=temperature,
             top_p=top_p,
             top_k=top_k,
@@ -172,6 +183,8 @@ def extract(
             model=model,
             api_key=api_key,
             max_concurrent=max_concurrent,
+            max_tokens=max_tokens,
+            max_context=max_context,
             temperature=temperature,
             top_p=top_p,
             top_k=top_k,
@@ -237,6 +250,7 @@ def extract(
         judge_context_tokens=judge_context_tokens,
         expand_siblings=expand_siblings,
         grounding_passes=grounding_passes,
+        grounding_batch_size=grounding_batch_size,
         expansion_passes=expansion_passes,
         no_causal_synthesis=no_causal_synthesis,
         query_gen=query_gen,

--- a/src/asago_policy_mapper/extract/models.py
+++ b/src/asago_policy_mapper/extract/models.py
@@ -202,7 +202,7 @@ class RetrievalConfig:
     grounding_passes: int = 3
     expansion_passes: int = 3
     no_causal_synthesis: bool = False
-    grounding_batch_size: int = 0
+    grounding_batch_size: int = 15
     query_gen: bool = True
 
     @property
@@ -238,5 +238,6 @@ class RetrievalConfig:
             "grounding_passes": self.grounding_passes,
             "expansion_passes": self.expansion_passes,
             "no_causal_synthesis": self.no_causal_synthesis,
+            "grounding_batch_size": self.grounding_batch_size,
             "query_gen": self.query_gen,
         }

--- a/src/asago_policy_mapper/extract/pipeline.py
+++ b/src/asago_policy_mapper/extract/pipeline.py
@@ -40,6 +40,18 @@ from asago_policy_mapper.llm import LLMConfig
 
 logger = logging.getLogger(__name__)
 
+_QUERY_GEN_MAX_CANDIDATES = 50
+
+
+def _cap_accepted_candidates(chunk_results: list[ChunkResult], limit: int) -> None:
+    """Keep the highest-RRF candidates when query-gen unions exceed the per-chunk cap."""
+    for cr in chunk_results:
+        if cr is None or len(cr.accepted) <= limit:
+            continue
+        cr.accepted = sorted(cr.accepted, key=lambda c: c.rrf_score, reverse=True)[:limit]
+        cr.stats["auto_accepted"] = len(cr.accepted)
+        cr.stats["candidates_retrieved"] = max(cr.stats.get("candidates_retrieved", 0), len(cr.accepted))
+
 
 @contextmanager
 def timed(timing, key):
@@ -213,6 +225,14 @@ def _run_grounding(
     ground_tasks = [cr for cr in chunk_results if cr.accepted]
     for cr in ground_tasks:
         total_candidates += len(cr.accepted)
+
+    logger.info(
+        "Grounding %d chunks with %d candidates (%d passes, batch_size=%d)",
+        len(ground_tasks),
+        total_candidates,
+        grounding_passes,
+        grounding_batch_size,
+    )
 
     if ground_tasks:
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
@@ -390,13 +410,18 @@ def _run_judge(
     chunk_contexts=None,
 ):
     max_workers = config.max_concurrent
+    judge_tasks = [(i, cr) for i, cr in enumerate(chunk_results) if cr.borderline]
+    logger.info(
+        "Judge: %d chunks with borderline candidates (no_judge=%s)",
+        len(judge_tasks),
+        retrieval.no_judge,
+    )
     if retrieval.no_judge:
         for cr in chunk_results:
             if cr.borderline:
                 cr.borderline_judged = list(cr.borderline)
                 cr.accepted.extend(cr.borderline)
     elif retrieval.use_cross_encoder:
-        judge_tasks = [(i, cr) for i, cr in enumerate(chunk_results) if cr.borderline]
         if judge_tasks:
             with ThreadPoolExecutor(max_workers=max_workers) as pool:
                 futures = {
@@ -485,6 +510,12 @@ def _run_expansion(
         len(chunks),
     )
     stats["expansion_groups"] = len(groups)
+    logger.info(
+        "Expansion: %d sibling candidates in %d groups (%d passes)",
+        stats["expanded_candidates"],
+        stats["expansion_groups"],
+        expansion_passes,
+    )
 
     def _ground_group(group):
         return ground_risk_group(
@@ -564,6 +595,7 @@ def _run_causal_synthesis(merged, chunks, client, config, max_workers, call_coll
         )
 
     results: dict[str, _CausalChain | None] = {}
+    logger.info("Causal synthesis: %d risks", len(merged))
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         futures = {pool.submit(_synthesize_one, m): m for m in merged}
         for future in as_completed(futures):
@@ -696,6 +728,8 @@ def run_extraction(
                             },
                         )
 
+            _cap_accepted_candidates(chunk_results, _QUERY_GEN_MAX_CANDIDATES)
+
             retrieval_indices = fallback_chunk_indices | {i for i in range(len(chunks)) if chunk_results[i] is None}
             for i in sorted(retrieval_indices):
                 cr = retrieve_chunk(
@@ -728,6 +762,13 @@ def run_extraction(
                     threshold_low=retrieval.threshold_low,
                 )
                 chunk_results[i] = cr
+
+    n_accepted = sum(len(cr.accepted) for cr in chunk_results if cr is not None)
+    logger.info(
+        "Retrieval complete: %d chunks, %d accepted candidates",
+        len(chunks),
+        n_accepted,
+    )
 
     if index.variant_map and retrieval.no_grounding:
         for cr in chunk_results:

--- a/src/asago_policy_mapper/llm.py
+++ b/src/asago_policy_mapper/llm.py
@@ -175,8 +175,7 @@ def create_client(
         OpenAI(base_url=config.base_url, api_key=config.api_key),
         mode=mode,
     )
-    if tracker is not None:
-        _wrap_with_tracking(client, tracker, config)
+    _wrap_with_tracking(client, tracker if tracker is not None else TokenTracker(), config)
     return client
 
 
@@ -228,6 +227,7 @@ def _truncate_messages(messages: list[dict[str, str]]) -> list[dict[str, str]] |
 
 
 def _apply_budget(kwargs: dict, config: LLMConfig) -> None:
+    kwargs.setdefault("max_tokens", config.max_tokens)
     if config.max_context > 0:
         messages = kwargs.get("messages", [])
         requested = kwargs.get("max_tokens", config.max_tokens)

--- a/src/asago_policy_mapper/templates/prompts/ground_evidence_system.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_evidence_system.j2
@@ -4,4 +4,4 @@ For each risk, determine whether the chunk actually discusses, addresses, or imp
 
 Focus on semantic relevance, not exact keyword matches. A passage about "unlawful monitoring of individuals" is evidence for a "mass surveillance" risk. A passage about "face recognition opt-out rights" is evidence for a "biometric identification" risk.
 
-Only mark a risk as grounded if the text genuinely discusses that risk concept. Do not mark a risk as grounded just because the text is about AI in general. When rejecting a risk, briefly explain why the text does not support it.
+Only mark a risk as grounded if the text genuinely discusses that risk concept. Do not mark a risk as grounded just because the text is about AI in general. For ungrounded risks, set grounded to false and quotes to an empty list — do not write a rejection explanation.

--- a/src/asago_policy_mapper/templates/prompts/ground_evidence_system.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_evidence_system.j2
@@ -4,4 +4,4 @@ For each risk, determine whether the chunk actually discusses, addresses, or imp
 
 Focus on semantic relevance, not exact keyword matches. A passage about "unlawful monitoring of individuals" is evidence for a "mass surveillance" risk. A passage about "face recognition opt-out rights" is evidence for a "biometric identification" risk.
 
-Only mark a risk as grounded if the text genuinely discusses that risk concept. Do not mark a risk as grounded just because the text is about AI in general. For ungrounded risks, set grounded to false and quotes to an empty list — do not write a rejection explanation.
+Only mark a risk as grounded if the text genuinely discusses that risk concept. Do not mark a risk as grounded just because the text is about AI in general. If grounded is true, quotes MUST contain at least one exact substring from the text. If grounded is false, set quotes to an empty list — do not write a rejection explanation.

--- a/src/asago_policy_mapper/templates/prompts/ground_evidence_user.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_evidence_user.j2
@@ -12,6 +12,6 @@ For each risk, respond with:
 - risk_id: the exact risk ID from above
 - grounded: true if the chunk discusses this risk, false otherwise
 - confidence: "high", "medium", or "low"
-- quotes: the specific passages from the chunk that ground this risk (empty list if not grounded)
+- quotes: if grounded is true, at least one exact substring from the chunk; if grounded is false, an empty list
 
-Do not add extra fields. For ungrounded risks, set quotes to an empty list.
+Do not add extra fields. Do not write a rejection explanation.

--- a/src/asago_policy_mapper/templates/prompts/ground_evidence_user.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_evidence_user.j2
@@ -13,4 +13,5 @@ For each risk, respond with:
 - grounded: true if the chunk discusses this risk, false otherwise
 - confidence: "high", "medium", or "low"
 - quotes: the specific passages from the chunk that ground this risk (empty list if not grounded)
-- rejection_reason: if not grounded, briefly explain why (empty string if grounded)
+
+Do not add extra fields. For ungrounded risks, set quotes to an empty list.

--- a/src/asago_policy_mapper/templates/prompts/ground_group_system.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_group_system.j2
@@ -4,4 +4,4 @@ For each risk, determine whether ANY of the passages discusses, addresses, or im
 
 Focus on semantic relevance, not exact keyword matches. A passage about "unlawful monitoring of individuals" is evidence for a "mass surveillance" risk. A passage about "face recognition opt-out rights" is evidence for a "biometric identification" risk.
 
-Only mark a risk as grounded if a passage genuinely discusses that risk concept. Do not mark a risk as grounded just because the text is about AI in general. For ungrounded risks, set grounded to false and quotes to an empty list — do not write a rejection explanation.
+Only mark a risk as grounded if a passage genuinely discusses that risk concept. Do not mark a risk as grounded just because the text is about AI in general. If grounded is true, quotes MUST contain at least one exact substring from the passages. If grounded is false, set quotes to an empty list — do not write a rejection explanation.

--- a/src/asago_policy_mapper/templates/prompts/ground_group_system.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_group_system.j2
@@ -4,4 +4,4 @@ For each risk, determine whether ANY of the passages discusses, addresses, or im
 
 Focus on semantic relevance, not exact keyword matches. A passage about "unlawful monitoring of individuals" is evidence for a "mass surveillance" risk. A passage about "face recognition opt-out rights" is evidence for a "biometric identification" risk.
 
-Only mark a risk as grounded if a passage genuinely discusses that risk concept. Do not mark a risk as grounded just because the text is about AI in general. When rejecting a risk, briefly explain why the text does not support it.
+Only mark a risk as grounded if a passage genuinely discusses that risk concept. Do not mark a risk as grounded just because the text is about AI in general. For ungrounded risks, set grounded to false and quotes to an empty list — do not write a rejection explanation.

--- a/src/asago_policy_mapper/templates/prompts/ground_group_user.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_group_user.j2
@@ -18,4 +18,5 @@ For each risk, respond with:
 - grounded: true if any passage discusses this risk, false otherwise
 - confidence: "high", "medium", or "low"
 - quotes: the specific passages that ground this risk (empty list if not grounded)
-- rejection_reason: if not grounded, briefly explain why (empty string if grounded)
+
+Do not add extra fields. For ungrounded risks, set quotes to an empty list.

--- a/src/asago_policy_mapper/templates/prompts/ground_group_user.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_group_user.j2
@@ -17,6 +17,6 @@ For each risk, respond with:
 - risk_id: the exact risk ID from above
 - grounded: true if any passage discusses this risk, false otherwise
 - confidence: "high", "medium", or "low"
-- quotes: the specific passages that ground this risk (empty list if not grounded)
+- quotes: if grounded is true, at least one exact substring from the passages; if grounded is false, an empty list
 
-Do not add extra fields. For ungrounded risks, set quotes to an empty list.
+Do not add extra fields. Do not write a rejection explanation.

--- a/src/asago_policy_mapper/templates/prompts/ground_variants_user.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_variants_user.j2
@@ -17,4 +17,5 @@ For each variant, respond with:
 - grounded: true ONLY if the text specifically discusses this variant's distinguishing sub-type, false otherwise
 - confidence: "high", "medium", or "low"
 - quotes: the specific passages from the chunk that evidence this PARTICULAR sub-type (empty list if not grounded)
-- rejection_reason: if not grounded, explain what specific evidence would be needed (empty string if grounded)
+
+Do not add extra fields. For ungrounded variants, set quotes to an empty list.

--- a/src/asago_policy_mapper/templates/prompts/ground_variants_user.j2
+++ b/src/asago_policy_mapper/templates/prompts/ground_variants_user.j2
@@ -16,6 +16,6 @@ For each variant, respond with:
 - risk_id: the exact variant risk ID from above
 - grounded: true ONLY if the text specifically discusses this variant's distinguishing sub-type, false otherwise
 - confidence: "high", "medium", or "low"
-- quotes: the specific passages from the chunk that evidence this PARTICULAR sub-type (empty list if not grounded)
+- quotes: if grounded is true, at least one exact substring from the chunk that evidences this PARTICULAR sub-type; if grounded is false, an empty list
 
-Do not add extra fields. For ungrounded variants, set quotes to an empty list.
+Do not add extra fields. Do not write a rejection explanation.

--- a/tests/test_extract_pipeline.py
+++ b/tests/test_extract_pipeline.py
@@ -17,11 +17,13 @@ from asago_policy_mapper.extract.models import (
     _RiskEvidenceList,
 )
 from asago_policy_mapper.extract.pipeline import (
+    _cap_accepted_candidates,
     _run_causal_synthesis,
     build_risk_match,
     determine_accepted_by,
     run_extraction,
 )
+from asago_policy_mapper.extract.retrieve import ChunkResult
 
 
 def _make_risk(id, name, description, concern="", parent=""):
@@ -722,3 +724,22 @@ def test_run_extraction_query_gen_no_judge_no_grounding(mock_config, tmp_path):
     for risk in result.risks:
         assert risk.evidence == []
         assert risk.grounding_confidence == "ungrounded"
+
+
+def test_cap_accepted_candidates_keeps_highest_rrf():
+    low = ScoredCandidate(risk_id="low", risk_name="L", risk_description="", rrf_score=0.01)
+    high = ScoredCandidate(risk_id="high", risk_name="H", risk_description="", rrf_score=0.9)
+    mid = ScoredCandidate(risk_id="mid", risk_name="M", risk_description="", rrf_score=0.2)
+    cr = ChunkResult(
+        chunk_index=0,
+        source="doc.md",
+        page=None,
+        section=None,
+        accepted=[low, high, mid],
+        borderline=[],
+        borderline_judged=[],
+        stats={"auto_accepted": 3, "candidates_retrieved": 3},
+    )
+    _cap_accepted_candidates([cr], limit=2)
+    assert [c.risk_id for c in cr.accepted] == ["high", "mid"]
+    assert cr.stats["auto_accepted"] == 2

--- a/tests/test_extract_querygen.py
+++ b/tests/test_extract_querygen.py
@@ -13,6 +13,7 @@ from asago_policy_mapper.extract.querygen import (
 def test_retrieval_config_query_gen_default_true():
     rc = RetrievalConfig()
     assert rc.query_gen is True
+    assert rc.grounding_batch_size == 15
 
 
 def test_retrieval_config_query_gen_in_metadata():

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -609,3 +609,35 @@ class TestRetryWithValidation:
         user_hints = [m for m in retry_messages if m["role"] == "user" and "Validation error:" in m["content"]]
         assert len(user_hints) == 1
         assert "bad field" in user_hints[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# _apply_budget
+# ---------------------------------------------------------------------------
+
+
+class TestApplyBudget:
+    def test_sets_max_tokens_when_max_context_is_zero(self):
+        from asago_policy_mapper.llm import _apply_budget
+
+        config = LLMConfig(base_url="http://test", model="test-model", max_tokens=8192, max_context=0)
+        kwargs: dict = {"messages": [{"role": "user", "content": "hello"}]}
+        _apply_budget(kwargs, config)
+        assert kwargs["max_tokens"] == 8192
+
+    def test_does_not_override_explicit_max_tokens(self):
+        from asago_policy_mapper.llm import _apply_budget
+
+        config = LLMConfig(base_url="http://test", model="test-model", max_tokens=8192, max_context=0)
+        kwargs: dict = {"messages": [{"role": "user", "content": "hello"}], "max_tokens": 256}
+        _apply_budget(kwargs, config)
+        assert kwargs["max_tokens"] == 256
+
+    def test_budgets_against_max_context(self):
+        from asago_policy_mapper.llm import _apply_budget
+
+        config = LLMConfig(base_url="http://test", model="test-model", max_tokens=8192, max_context=2048)
+        kwargs: dict = {"messages": [{"role": "user", "content": "hello"}]}
+        _apply_budget(kwargs, config)
+        assert kwargs["max_tokens"] < 8192
+        assert kwargs["max_tokens"] >= 256

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -139,6 +139,9 @@ LLM_TEST_RISKS = [
     ),
 ]
 
+# Same three risks as SAMPLE_CANDIDATES, as taxonomy objects for run_extraction.
+LLM_QUERYGEN_RISKS = [r for r in LLM_TEST_RISKS if r.id in {"R-BIAS", "R-TRANSPARENCY", "R-ROBOT"}]
+
 
 @pytest.fixture(scope="session")
 def llm_config():
@@ -453,7 +456,7 @@ def test_pipeline_e2e_no_querygen(llm_client, llm_config, tiny_document, small_r
     _log_extraction_result(result)
 
 
-def test_pipeline_e2e_with_querygen(llm_client, llm_config, tiny_document, small_risk_set):
+def test_pipeline_e2e_with_querygen(llm_client, llm_config, tiny_document):
     """Full pipeline with query generation (default path)."""
     client, _ = llm_client
 
@@ -461,7 +464,7 @@ def test_pipeline_e2e_with_querygen(llm_client, llm_config, tiny_document, small
         documents=[tiny_document],
         client=client,
         config=llm_config,
-        risks=small_risk_set,
+        risks=LLM_QUERYGEN_RISKS,
         retrieval=RetrievalConfig(
             query_gen=True,
             grounding_passes=1,


### PR DESCRIPTION
## Summary

Fix extraction hangs against vLLM by bounding every LLM completion and shrinking grounding JSON so instructor can parse it on the first try.

Chat completions only stop when the model emits a stop token or hits `max_tokens`. Grounding uses instructor JSON mode, and models often keep writing after a valid JSON object. Four changes close that loop:

### Always send `max_tokens` (default 8192); wrap the client even without a tracker

The wrapper used to set `max_tokens` only if `max_context > 0`. An `LLMConfig(base_url=..., model=..., api_key=...)` left `max_context` at 0, so the field was omitted. vLLM then treats that as “use the rest of the context window.” One call can generate tens of thousands of tokens.

Without a tracker, `create_client` used to skip the wrapper entirely, so temperature, retries, and `max_tokens` never applied. Wrapping always means every pipeline call gets a hard output cap.

This is the main “request never ends” fix.

New CLI flags: `--max-tokens` / `--max-context`.

### Default `grounding_batch_size=15` so each JSON response stays bounded

Grounding asks for a JSON list of every candidate (`risk_id`, `grounded`, `confidence`, `quotes`). Query-gen was sending dozens of risks in one prompt.

If the model tries to emit 50–200 items with quotes, the JSON is larger than 8192 tokens. Instructor sees truncated JSON (`IncompleteOutputException`), retries, maybe truncates the prompt and tries again. You pay for a full `max_tokens` generation several times per chunk, times 3 grounding passes, in parallel.

Batches of 15 keep a single completion small enough to finish as valid JSON on the first try, so those retry loops mostly go away.

Override with `--grounding-batch-size` (`0` = no split).

### Cap query-gen unions at 50 candidates per chunk (highest RRF)

With query-gen on, each LLM query returns up to 50 risks, and every query’s hits are unioned onto every chunk in that section. Several queries on the same group can put 100+ unique risks on one chunk.

That inflates grounding: more tokens in the prompt, a larger required JSON list, more truncation/retries, and more work in later stages (variants, expansion, causal synthesis).

Capping at 50 (best RRF scores) restores a per-chunk ceiling like a single `hybrid_search(..., top_k=50)`.

### Stop asking for `rejection_reason`

The prompts told the model to explain every rejected risk. Almost all query-gen candidates are rejects, so the model wrote a short essay per risk.

The Pydantic schema has no `rejection_reason` field. Extra text either bloated the completion until `max_tokens`, or broke JSON validation and triggered instructor retries (another full generation).

## Test plan

- [ ] `uv run pytest tests/test_llm.py tests/test_extract_pipeline.py tests/test_extract_querygen.py -q`
- [ ] Confirm `extract` without `--max-context` still sends `max_tokens=8192` (vLLM no longer fills the remaining window)
- [ ] Confirm a notebook-style `LLMConfig(base_url=..., model=..., api_key=...)` now caps output
- [ ] Smoke an extract with query-gen on: grounding logs show `batch_size=15`, candidates per chunk ≤ 50
- [ ] Optional: `--grounding-batch-size 0` still works for comparison